### PR TITLE
add ci check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+sudo: false
+
+language: rust
+matrix:
+  include:
+    - os: linux
+      rust: stable
+    - os: linux
+      rust: nightly
+    - os: windows
+      rust: stable
+    - os: osx
+      rust: stable
+env:
+  global:
+    - RUST_BACKTRACE=1
+    - RUSTFLAGS="-D warnings"
+
+install:
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then rustup component add rustfmt; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then rustup component add clippy; fi
+
+script:
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo fmt -- --check; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" && $TRAVIS_OS_NAME == "linux" ]]; then cargo clippy -- -D clippy::all; fi
+  - cargo test --all -- --nocapture
+  - cargo test --all --all-features -- --nocapture
+  # Validate features and benches too.
+  - cargo bench --all -- --test
+  - cargo bench --all --all-features -- --test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # yatp
 Yet another thread pool in Rust that is adaptive, responsive and generic.
+
+[![Build Status](https://travis-ci.org/tikv/yatp.svg?branch=master)](https://travis-ci.org/tikv/yatp)


### PR DESCRIPTION
The PR adds basic CI checks. The configuration is copied from tikv/fail-rs. Some configuration may not be useful yet, but all should be utilized in the future.