### PR TITLE
use TaskCell everywhere and remove TaskContext

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,4 @@ mod runner;
 pub mod task;
 
 pub use self::pool::{Builder, Remote, ThreadPool};
-pub use self::runner::{LocalSpawn, RemoteSpawn, RemoteTask, Runner};
+pub use self::runner::{LocalSpawn, RemoteSpawn, Runner, TaskCell};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,4 @@ mod runner;
 pub mod task;
 
 pub use self::pool::{Builder, Remote, ThreadPool};
-pub use self::runner::{LocalSpawn, RemoteSpawn, Runner, TaskCell};
+pub use self::runner::{LocalSpawn, RemoteSpawn, Runner};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,4 +11,4 @@ mod runner;
 pub mod task;
 
 pub use self::pool::{Builder, Remote, ThreadPool};
-pub use self::runner::{LocalSpawn, RemoteSpawn, Runner};
+pub use self::runner::{LocalSpawn, RemoteSpawn, RemoteTask, Runner};

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -53,7 +53,7 @@ impl<Q: TaskQueue> LazyBuilder<Q> {
     pub fn build<F>(self, mut factory: F) -> ThreadPool<Q>
     where
         F: RunnerBuilder,
-        F::Runner: Runner<Task = Q::Task> + Send + 'static,
+        F::Runner: Runner + Send + 'static,
     {
         let mut threads = Vec::with_capacity(self.builder.sched_config.max_thread_count);
         for i in 0..self.builder.sched_config.max_thread_count {
@@ -181,8 +181,7 @@ impl Builder {
     where
         Q: TaskQueue,
         B: RunnerBuilder,
-        B::Runner: Runner<Task = Q::Task> + Send + 'static,
-        <<B as RunnerBuilder>::Runner as Runner>::Task: Send,
+        B::Runner: Runner + Send + 'static,
     {
         self.freeze().1.build(builder)
     }
@@ -198,7 +197,7 @@ impl<Q: TaskQueue> ThreadPool<Q> {
     /// Spawns the task into the thread pool.
     ///
     /// If the pool is shutdown, it becomes no-op.
-    pub fn spawn(&self, t: impl Into<Q::Task>) {
+    pub fn spawn(&self, t: impl Into<Q::TaskCell>) {
         self.queue.push(t.into());
     }
 
@@ -239,7 +238,7 @@ impl<Q: TaskQueue> Remote<Q> {
     /// Spawns the tasks into thread pool.
     ///
     /// If the thread pool is shutdown, it becomes no-op.
-    pub fn spawn(&self, t: impl Into<Q::Task>) {
+    pub fn spawn(&self, t: impl Into<Q::TaskCell>) {
         self.queue.push(t.into());
     }
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -8,7 +8,7 @@
 /// data struct.
 pub trait TaskQueue: Clone {
     type Consumer;
-    type Task;
+    type TaskCell;
 
     /// Creates a queue with a promise to only use at most `con` consumers
     /// at the same time.
@@ -17,7 +17,7 @@ pub trait TaskQueue: Clone {
     /// Pushes a task to the queue.
     ///
     /// If the queue is closed, the method should behave like no-op.
-    fn push(&self, task: Self::Task);
+    fn push(&self, task: Self::TaskCell);
 
     /// Closes the queue so that no more tasks can be scheduled.
     fn close(&self);

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -1,5 +1,19 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+/// A cell containing a task and needed extra information.
+pub trait TaskCell {
+    /// Extra information in the cell.
+    type Extras;
+
+    /// Gets mutable extra information.
+    ///
+    /// # Safety
+    ///
+    /// This method is not safe. The caller must ensure that he is the only
+    /// one accessing the extras.
+    unsafe fn mut_extras(&mut self) -> &mut Self::Extras;
+}
+
 /// A Task queue for thread pool.
 ///
 /// Unlike a general MPMC queues, it's not required to be `Sync` on the
@@ -8,7 +22,7 @@
 /// data struct.
 pub trait TaskQueue: Clone {
     type Consumer;
-    type TaskCell;
+    type TaskCell: TaskCell;
 
     /// Creates a queue with a promise to only use at most `con` consumers
     /// at the same time.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -6,12 +6,7 @@ pub trait TaskCell {
     type Extras;
 
     /// Gets mutable extra information.
-    ///
-    /// # Safety
-    ///
-    /// This method is not safe. The caller must ensure that he is the only
-    /// one accessing the extras.
-    unsafe fn mut_extras(&mut self) -> &mut Self::Extras;
+    fn mut_extras(&mut self) -> &mut Self::Extras;
 }
 
 /// A Task queue for thread pool.

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -36,12 +36,7 @@ pub trait Runner {
     /// It's possible that a task can't be finished in a single execution, in
     /// which case feel free to spawn the task again and return false to
     /// indicate the task has not been finished yet.
-    fn handle(
-        &mut self,
-        spawn: &mut Self::Spawn,
-        task: Self::Task,
-        ctx: &<Self::Spawn as LocalSpawn>::TaskContext,
-    ) -> bool;
+    fn handle(&mut self, spawn: &mut Self::Spawn, task: Self::Task) -> bool;
 
     /// Called when the runner is put to sleep.
     fn pause(&mut self, _spawn: &mut Self::Spawn) -> bool {
@@ -78,30 +73,15 @@ pub trait RemoteSpawn: Sync + Send {
 pub trait LocalSpawn {
     /// The task it can spawn.
     type Task;
-    /// The context that associated with the task.
-    type TaskContext;
     /// The remote handle that can be used in other threads.
     type Remote: RemoteSpawn;
 
     /// Spawns a task into the thread pool.
-    fn spawn_ctx(&mut self, task: impl Into<Self::Task>, ctx: &Self::TaskContext);
+    fn spawn(&mut self, task: impl Into<Self::Task>);
 
     /// Gets a remote instance to allow spawn task back to the pool.
     fn remote(&self) -> Self::Remote;
 }
-
-/// Extensions to `[LocalSpawn]`.
-pub trait LocalSpawnExt: LocalSpawn {
-    /// Spawns a task into the thread pool.
-    fn spawn(&mut self, t: impl Into<Self::Task>)
-    where
-        Self::TaskContext: Default,
-    {
-        self.spawn_ctx(t, &Default::default())
-    }
-}
-
-impl<S: LocalSpawn> LocalSpawnExt for S {}
 
 /// A builder trait that produce `Runner`.
 pub trait RunnerBuilder {

--- a/src/runner.rs
+++ b/src/runner.rs
@@ -53,18 +53,10 @@ pub trait Runner {
     fn end(&mut self, _spawn: &mut Self::Spawn) {}
 }
 
-/// A task which can be spawned. It also contains necessary spawn options.
-pub trait TaskCell<SpawnOptions> {
-    /// Gets the spawn options.
-    fn spawn_options(&self) -> &SpawnOptions;
-}
-
 /// Allows spawning a task to the thread pool from a different thread.
 pub trait RemoteSpawn: Sync + Send {
     /// The task it can spawn.
-    type TaskCell: TaskCell<Self::SpawnOptions>;
-    /// The spawn options.
-    type SpawnOptions;
+    type TaskCell;
 
     /// Spawns a task into the thread pool.
     fn spawn(&self, task_cell: Self::TaskCell);
@@ -73,11 +65,9 @@ pub trait RemoteSpawn: Sync + Send {
 /// Allows spawning a task inside the thread pool.
 pub trait LocalSpawn {
     /// The task it can spawn.
-    type TaskCell: TaskCell<Self::SpawnOptions>;
-    /// The spawn options.
-    type SpawnOptions;
+    type TaskCell;
     /// The remote handle that can be used in other threads.
-    type Remote: RemoteSpawn<TaskCell = Self::TaskCell, SpawnOptions = Self::SpawnOptions>;
+    type Remote: RemoteSpawn<TaskCell = Self::TaskCell>;
 
     /// Spawns a task into the thread pool.
     fn spawn(&mut self, task: Self::TaskCell);

--- a/src/task/callback.rs
+++ b/src/task/callback.rs
@@ -37,7 +37,7 @@ pub struct TaskCell<Spawn, Extras> {
 impl<Spawn, Extras> crate::queue::TaskCell for TaskCell<Spawn, Extras> {
     type Extras = Extras;
 
-    unsafe fn mut_extras(&mut self) -> &mut Self::Extras {
+    fn mut_extras(&mut self) -> &mut Self::Extras {
         &mut self.extras
     }
 }


### PR DESCRIPTION
This PR adds `TaskCell` trait. With this trait, the queue can get the spawn options from it. To spawn a task, one should use spawn a `TaskCell`.

`TaskContext` is removed. The only use of `TaskContext` is for spawning through `LocalSpawn`. The runner actually cannot utilize any data in it. So it can be managed by the queue itself and needn't be known by the runner.