### PR TITLE
queue: use enum instead of generic

### DIFF
--- a/src/queue.rs
+++ b/src/queue.rs
@@ -8,26 +8,33 @@
 //! which make it possible to do extreme optimizations and define complicated
 //! data structs.
 
-pub mod simple;
+mod extras;
+mod simple;
+
+pub use self::extras::Extras;
 
 use std::time::Instant;
 
 /// A cell containing a task and needed extra information.
 pub trait TaskCell {
-    /// Extra information in the cell.
-    type Extras;
-
     /// Gets mutable extra information.
-    fn mut_extras(&mut self) -> &mut Self::Extras;
+    fn mut_extras(&mut self) -> &mut Extras;
 }
 
 /// The injector of a task queue.
-pub trait TaskInjector: Clone {
-    /// The task cell in the queue.
-    type TaskCell: TaskCell;
+pub struct TaskInjector<T>(InjectorInner<T>);
 
+enum InjectorInner<T> {
+    Simple(simple::QueueInjector<T>),
+}
+
+impl<T: TaskCell + Send> TaskInjector<T> {
     /// Pushes a task to the queue.
-    fn push(&self, task_cell: Self::TaskCell);
+    pub fn push(&self, task_cell: T) {
+        match self.0 {
+            InjectorInner::Simple(ref s) => s.push(task_cell),
+        }
+    }
 }
 
 /// Popped task cell from a task queue.
@@ -44,14 +51,37 @@ pub struct Pop<T> {
 }
 
 /// The local queue of a task queue.
-pub trait LocalQueue {
-    /// The task cell in the queue.
-    type TaskCell: TaskCell;
+pub struct LocalQueue<T>(LocalQueueInner<T>);
 
+enum LocalQueueInner<T> {
+    Simple(simple::QueueLocal<T>),
+}
+
+impl<T: TaskCell + Send> LocalQueue<T> {
     /// Pushes a task to the local queue.
-    fn push(&mut self, task_cell: Self::TaskCell);
+    pub fn push(&mut self, task_cell: T) {
+        match self.0 {
+            LocalQueueInner::Simple(ref mut s) => s.push(task_cell),
+        }
+    }
 
     /// Gets a task cell from the queue. Returns `None` if there is no task cell
     /// available.
-    fn pop(&mut self) -> Option<Pop<Self::TaskCell>>;
+    pub fn pop(&mut self) -> Option<Pop<T>> {
+        match self.0 {
+            LocalQueueInner::Simple(ref mut s) => s.pop(),
+        }
+    }
+}
+
+/// Creates a task queue that allows given number consumers.
+pub fn simple<T>(local_num: usize) -> (TaskInjector<T>, Vec<LocalQueue<T>>) {
+    let (injector, locals) = simple::create(local_num);
+    (
+        TaskInjector(InjectorInner::Simple(injector)),
+        locals
+            .into_iter()
+            .map(|i| LocalQueue(LocalQueueInner::Simple(i)))
+            .collect(),
+    )
 }

--- a/src/queue/extras.rs
+++ b/src/queue/extras.rs
@@ -4,8 +4,7 @@ use std::time::Instant;
 
 /// The extras for the task cells pushed into a simple task queue.
 ///
-/// [`Default::default`] can be used to create a [`SimpleQueueExtras`] for
-/// a task cell.
+/// [`Default::default`] can be used to create a [`Extras`] for a task cell.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct Extras {
     /// The instant when the task cell is pushed to the queue.

--- a/src/queue/extras.rs
+++ b/src/queue/extras.rs
@@ -1,0 +1,13 @@
+// Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::time::Instant;
+
+/// The extras for the task cells pushed into a simple task queue.
+///
+/// [`Default::default`] can be used to create a [`SimpleQueueExtras`] for
+/// a task cell.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Extras {
+    /// The instant when the task cell is pushed to the queue.
+    pub schedule_time: Option<Instant>,
+}

--- a/src/queue/simple.rs
+++ b/src/queue/simple.rs
@@ -2,11 +2,10 @@
 
 //! A simple task queue.
 //!
-//! This task queue requires [`TaskCell`] to contain [`SimpleQueueExtras`]
-//! as its extras. The instant when the task cell is pushed into the queue
-//! is recorded in the extras.
+//! The instant when the task cell is pushed into the queue is recorded
+//! in the extras.
 
-use super::{LocalQueue, Pop, TaskCell, TaskInjector};
+use super::{Pop, TaskCell};
 
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 use rand::prelude::*;
@@ -15,68 +14,54 @@ use std::sync::Arc;
 use std::time::Instant;
 
 /// The injector of a simple task queue.
-pub struct SimpleQueueInjector<T>(Arc<Injector<T>>);
+pub struct QueueInjector<T>(Arc<Injector<T>>);
 
-impl<T: TaskCell> Clone for SimpleQueueInjector<T> {
+impl<T: TaskCell> Clone for QueueInjector<T> {
     fn clone(&self) -> Self {
-        SimpleQueueInjector(self.0.clone())
+        QueueInjector(self.0.clone())
     }
-}
-
-/// The extras for the task cells pushed into a simple task queue.
-///
-/// [`Default::default`] can be used to create a [`SimpleQueueExtras`] for
-/// a task cell.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct SimpleQueueExtras {
-    /// The instant when the task cell is pushed to the queue.
-    schedule_time: Option<Instant>,
 }
 
 fn set_schedule_time<T>(task_cell: &mut T)
 where
-    T: TaskCell<Extras = SimpleQueueExtras>,
+    T: TaskCell,
 {
     task_cell.mut_extras().schedule_time = Some(Instant::now());
 }
 
-impl<T> TaskInjector for SimpleQueueInjector<T>
+impl<T> QueueInjector<T>
 where
-    T: TaskCell<Extras = SimpleQueueExtras>,
+    T: TaskCell + Send,
 {
-    type TaskCell = T;
-
     /// Pushes the task cell to the queue. The schedule time in the extras is
     /// assigned to be now.
-    fn push(&self, mut task_cell: Self::TaskCell) {
+    pub fn push(&self, mut task_cell: T) {
         set_schedule_time(&mut task_cell);
         self.0.push(task_cell);
     }
 }
 
 /// The local queue of a simple task queue.
-pub struct SimpleQueueLocal<T> {
+pub struct QueueLocal<T> {
     local_queue: Worker<T>,
     injector: Arc<Injector<T>>,
     stealers: Vec<Stealer<T>>,
     rng: SmallRng,
 }
 
-impl<T> LocalQueue for SimpleQueueLocal<T>
+impl<T> QueueLocal<T>
 where
-    T: TaskCell<Extras = SimpleQueueExtras>,
+    T: TaskCell,
 {
-    type TaskCell = T;
-
-    fn push(&mut self, mut task_cell: Self::TaskCell) {
+    pub fn push(&mut self, mut task_cell: T) {
         set_schedule_time(&mut task_cell);
         self.local_queue.push(task_cell);
     }
 
-    fn pop(&mut self) -> Option<Pop<Self::TaskCell>> {
+    pub fn pop(&mut self) -> Option<Pop<T>> {
         fn into_pop<T>(mut t: T, from_local: bool) -> Pop<T>
         where
-            T: TaskCell<Extras = SimpleQueueExtras>,
+            T: TaskCell,
         {
             let schedule_time = t.mut_extras().schedule_time.unwrap();
             Pop {
@@ -123,7 +108,7 @@ where
 }
 
 /// Creates a simple task queue with `local_num` local queues.
-pub fn create<T>(local_num: usize) -> (SimpleQueueInjector<T>, Vec<SimpleQueueLocal<T>>) {
+pub fn create<T>(local_num: usize) -> (QueueInjector<T>, Vec<QueueLocal<T>>) {
     let injector = Arc::new(Injector::new());
     let workers: Vec<_> = iter::repeat_with(Worker::new_lifo)
         .take(local_num)
@@ -139,7 +124,7 @@ pub fn create<T>(local_num: usize) -> (SimpleQueueInjector<T>, Vec<SimpleQueueLo
                 .filter(|(index, _)| *index != self_index)
                 .map(|(_, stealer)| stealer.clone())
                 .collect();
-            SimpleQueueLocal {
+            QueueLocal {
                 local_queue,
                 injector: injector.clone(),
                 stealers,
@@ -148,13 +133,14 @@ pub fn create<T>(local_num: usize) -> (SimpleQueueInjector<T>, Vec<SimpleQueueLo
         })
         .collect();
 
-    (SimpleQueueInjector(injector), local_queues)
+    (QueueInjector(injector), local_queues)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    use crate::queue::Extras;
     use std::sync::atomic::{AtomicI32, Ordering};
     use std::thread;
     use std::time::Duration;
@@ -162,7 +148,7 @@ mod tests {
     #[derive(Debug)]
     struct MockCell {
         value: i32,
-        extras: SimpleQueueExtras,
+        extras: Extras,
     }
 
     impl MockCell {
@@ -175,9 +161,7 @@ mod tests {
     }
 
     impl TaskCell for MockCell {
-        type Extras = SimpleQueueExtras;
-
-        fn mut_extras(&mut self) -> &mut SimpleQueueExtras {
+        fn mut_extras(&mut self) -> &mut Extras {
             &mut self.extras
         }
     }

--- a/src/task/callback.rs
+++ b/src/task/callback.rs
@@ -2,6 +2,7 @@
 
 //! A [`FnOnce`] or [`FnMut`] closure.
 
+use crate::queue::Extras;
 use crate::LocalSpawn;
 
 use std::marker::PhantomData;
@@ -27,17 +28,15 @@ impl<Spawn> Task<Spawn> {
 }
 
 /// The task cell for callback tasks.
-pub struct TaskCell<Spawn, Extras> {
+pub struct TaskCell<Spawn> {
     /// The callback task.
     pub task: Task<Spawn>,
     /// Extra information about the task.
     pub extras: Extras,
 }
 
-impl<Spawn, Extras> crate::queue::TaskCell for TaskCell<Spawn, Extras> {
-    type Extras = Extras;
-
-    fn mut_extras(&mut self) -> &mut Self::Extras {
+impl<Spawn> crate::queue::TaskCell for TaskCell<Spawn> {
+    fn mut_extras(&mut self) -> &mut Extras {
         &mut self.extras
     }
 }
@@ -51,9 +50,9 @@ pub struct Handle<'a, Spawn> {
     rerun: bool,
 }
 
-impl<'a, Spawn, Extras> Handle<'a, Spawn>
+impl<'a, Spawn> Handle<'a, Spawn>
 where
-    Spawn: LocalSpawn<TaskCell = TaskCell<Spawn, Extras>>,
+    Spawn: LocalSpawn<TaskCell = TaskCell<Spawn>>,
 {
     /// Spawns a [`FnOnce`] to the thread pool.
     pub fn spawn_once(
@@ -119,13 +118,22 @@ impl<Spawn> Default for Runner<Spawn> {
     }
 }
 
-impl<Spawn, Extras> crate::Runner for Runner<Spawn>
+impl<Spawn> Clone for Runner<Spawn> {
+    fn clone(&self) -> Runner<Spawn> {
+        Runner {
+            max_inplace_spin: self.max_inplace_spin,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<Spawn> crate::Runner for Runner<Spawn>
 where
-    Spawn: LocalSpawn<TaskCell = TaskCell<Spawn, Extras>>,
+    Spawn: LocalSpawn<TaskCell = TaskCell<Spawn>>,
 {
     type Spawn = Spawn;
 
-    fn handle(&mut self, spawn: &mut Spawn, mut task_cell: TaskCell<Spawn, Extras>) -> bool {
+    fn handle(&mut self, spawn: &mut Spawn, mut task_cell: TaskCell<Spawn>) -> bool {
         let mut handle = Handle {
             spawn,
             rerun: false,
@@ -168,10 +176,10 @@ mod tests {
     }
 
     impl LocalSpawn for MockSpawn {
-        type TaskCell = TaskCell<MockSpawn, ()>;
+        type TaskCell = TaskCell<MockSpawn>;
         type Remote = MockSpawn;
 
-        fn spawn(&mut self, _t: TaskCell<MockSpawn, ()>) {
+        fn spawn(&mut self, _t: TaskCell<MockSpawn>) {
             self.spawn_times += 1;
         }
 
@@ -181,9 +189,9 @@ mod tests {
     }
 
     impl RemoteSpawn for MockSpawn {
-        type TaskCell = TaskCell<MockSpawn, ()>;
+        type TaskCell = TaskCell<MockSpawn>;
 
-        fn spawn(&self, _task: TaskCell<MockSpawn, ()>) {
+        fn spawn(&self, _task: TaskCell<MockSpawn>) {
             unimplemented!()
         }
     }
@@ -199,7 +207,7 @@ mod tests {
                 task: Task::new_once(move |_| {
                     tx.send(42).unwrap();
                 }),
-                extras: (),
+                extras: Default::default(),
             },
         );
         assert_eq!(rx.recv().unwrap(), 42);
@@ -222,7 +230,7 @@ mod tests {
                         handle.set_rerun(true);
                     }
                 }),
-                extras: (),
+                extras: Default::default(),
             },
         );
         assert_eq!(rx.recv().unwrap(), 42);
@@ -248,7 +256,7 @@ mod tests {
                         handle.set_rerun(true);
                     }
                 }),
-                extras: (),
+                extras: Default::default(),
             },
         );
         assert_eq!(rx.recv().unwrap(), 42);

--- a/src/task/future.rs
+++ b/src/task/future.rs
@@ -2,6 +2,7 @@
 
 //! A [`Future`].
 
+use crate::queue::Extras;
 use crate::{LocalSpawn, RemoteSpawn};
 
 use std::cell::UnsafeCell;
@@ -19,7 +20,7 @@ use std::{fmt, mem};
 const DEFAULT_REPOLL_LIMIT: usize = 5;
 
 /// A [`Future`] task.
-pub struct Task<Remote, Extras> {
+pub struct Task<Remote> {
     status: AtomicU8,
     future: UnsafeCell<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>,
     remote: Remote,
@@ -27,13 +28,13 @@ pub struct Task<Remote, Extras> {
 }
 
 /// A [`Future`] task cell.
-pub struct TaskCell<Remote, Extras>(Arc<Task<Remote, Extras>>);
+pub struct TaskCell<Remote>(Arc<Task<Remote>>);
 
 // Safety: It is ensured that `future` and `extras` are always accessed by
 // only one thread at the same time.
-unsafe impl<Remote: Sync, Extras> Sync for Task<Remote, Extras> {}
+unsafe impl<Remote: Sync> Sync for Task<Remote> {}
 
-impl<Remote, Extras> fmt::Debug for TaskCell<Remote, Extras> {
+impl<Remote> fmt::Debug for TaskCell<Remote> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         "future::TaskCell".fmt(f)
@@ -52,7 +53,7 @@ const IDLE: u8 = 2;
 const POLLING: u8 = 3;
 const COMPLETED: u8 = 4;
 
-impl<Remote, Extras> TaskCell<Remote, Extras> {
+impl<Remote> TaskCell<Remote> {
     /// Creates a [`Future`] task cell that is ready to be polled.
     pub fn new<F: Future<Output = ()> + Send + 'static>(
         future: F,
@@ -68,58 +69,56 @@ impl<Remote, Extras> TaskCell<Remote, Extras> {
     }
 }
 
-impl<Remote, Extras> crate::queue::TaskCell for TaskCell<Remote, Extras> {
-    type Extras = Extras;
-
-    fn mut_extras(&mut self) -> &mut Self::Extras {
+impl<Remote> crate::queue::TaskCell for TaskCell<Remote> {
+    fn mut_extras(&mut self) -> &mut Extras {
         unsafe { &mut *self.0.extras.get() }
     }
 }
 
 #[inline]
-unsafe fn waker<Remote, Extras>(task: *const Task<Remote, Extras>) -> Waker
+unsafe fn waker<Remote>(task: *const Task<Remote>) -> Waker
 where
-    Remote: RemoteSpawn<TaskCell = TaskCell<Remote, Extras>>,
+    Remote: RemoteSpawn<TaskCell = TaskCell<Remote>>,
 {
     Waker::from_raw(RawWaker::new(
         task as *const (),
         &RawWakerVTable::new(
-            clone_raw::<Remote, Extras>,
-            wake_raw::<Remote, Extras>,
-            wake_ref_raw::<Remote, Extras>,
-            drop_raw::<Remote, Extras>,
+            clone_raw::<Remote>,
+            wake_raw::<Remote>,
+            wake_ref_raw::<Remote>,
+            drop_raw::<Remote>,
         ),
     ))
 }
 
 #[inline]
-unsafe fn clone_raw<Remote, Extras>(this: *const ()) -> RawWaker
+unsafe fn clone_raw<Remote>(this: *const ()) -> RawWaker
 where
-    Remote: RemoteSpawn<TaskCell = TaskCell<Remote, Extras>>,
+    Remote: RemoteSpawn<TaskCell = TaskCell<Remote>>,
 {
-    let task_cell = clone_task(this as *const Task<Remote, Extras>);
+    let task_cell = clone_task(this as *const Task<Remote>);
     RawWaker::new(
         Arc::into_raw(task_cell.0) as *const (),
         &RawWakerVTable::new(
-            clone_raw::<Remote, Extras>,
-            wake_raw::<Remote, Extras>,
-            wake_ref_raw::<Remote, Extras>,
-            drop_raw::<Remote, Extras>,
+            clone_raw::<Remote>,
+            wake_raw::<Remote>,
+            wake_ref_raw::<Remote>,
+            drop_raw::<Remote>,
         ),
     )
 }
 
 #[inline]
-unsafe fn drop_raw<Remote, Extras>(this: *const ())
+unsafe fn drop_raw<Remote>(this: *const ())
 where
-    Remote: RemoteSpawn<TaskCell = TaskCell<Remote, Extras>>,
+    Remote: RemoteSpawn<TaskCell = TaskCell<Remote>>,
 {
-    drop(task_cell(this as *const Task<Remote, Extras>))
+    drop(task_cell(this as *const Task<Remote>))
 }
 
-unsafe fn wake_impl<Remote, Extras>(task_cell: &TaskCell<Remote, Extras>)
+unsafe fn wake_impl<Remote>(task_cell: &TaskCell<Remote>)
 where
-    Remote: RemoteSpawn<TaskCell = TaskCell<Remote, Extras>>,
+    Remote: RemoteSpawn<TaskCell = TaskCell<Remote>>,
 {
     let task = &task_cell.0;
     let mut status = task.status.load(SeqCst);
@@ -152,32 +151,30 @@ where
 }
 
 #[inline]
-unsafe fn wake_raw<Remote, Extras>(this: *const ())
+unsafe fn wake_raw<Remote>(this: *const ())
 where
-    Remote: RemoteSpawn<TaskCell = TaskCell<Remote, Extras>>,
+    Remote: RemoteSpawn<TaskCell = TaskCell<Remote>>,
 {
-    let task_cell = task_cell(this as *const Task<Remote, Extras>);
+    let task_cell = task_cell(this as *const Task<Remote>);
     wake_impl(&task_cell);
 }
 
 #[inline]
-unsafe fn wake_ref_raw<Remote, Extras>(this: *const ())
+unsafe fn wake_ref_raw<Remote>(this: *const ())
 where
-    Remote: RemoteSpawn<TaskCell = TaskCell<Remote, Extras>>,
+    Remote: RemoteSpawn<TaskCell = TaskCell<Remote>>,
 {
-    let task_cell = ManuallyDrop::new(task_cell(this as *const Task<Remote, Extras>));
+    let task_cell = ManuallyDrop::new(task_cell(this as *const Task<Remote>));
     wake_impl(&task_cell);
 }
 
 #[inline]
-unsafe fn task_cell<Remote, Extras>(task: *const Task<Remote, Extras>) -> TaskCell<Remote, Extras> {
+unsafe fn task_cell<Remote>(task: *const Task<Remote>) -> TaskCell<Remote> {
     TaskCell(Arc::from_raw(task))
 }
 
 #[inline]
-unsafe fn clone_task<Remote, Extras>(
-    task: *const Task<Remote, Extras>,
-) -> TaskCell<Remote, Extras> {
+unsafe fn clone_task<Remote>(task: *const Task<Remote>) -> TaskCell<Remote> {
     let task_cell = task_cell(task);
     mem::forget(task_cell.0.clone());
     task_cell
@@ -211,14 +208,14 @@ impl<Spawn> Runner<Spawn> {
     }
 }
 
-impl<L, R, Extras> crate::Runner for Runner<L>
+impl<L, R> crate::Runner for Runner<L>
 where
-    L: LocalSpawn<TaskCell = TaskCell<R, Extras>, Remote = R>,
-    R: RemoteSpawn<TaskCell = TaskCell<R, Extras>>,
+    L: LocalSpawn<TaskCell = TaskCell<R>, Remote = R>,
+    R: RemoteSpawn<TaskCell = TaskCell<R>>,
 {
     type Spawn = L;
 
-    fn handle(&mut self, _local: &mut L, task_cell: TaskCell<R, Extras>) -> bool {
+    fn handle(&mut self, _local: &mut L, task_cell: TaskCell<R>) -> bool {
         let task = task_cell.0;
         unsafe {
             let waker = ManuallyDrop::new(waker(&*task));
@@ -258,7 +255,7 @@ mod tests {
 
     struct MockLocal {
         runner: Rc<RefCell<Runner<MockLocal>>>,
-        task_rx: mpsc::Receiver<TaskCell<MockRemote, ()>>,
+        task_rx: mpsc::Receiver<TaskCell<MockRemote>>,
         remote: MockRemote,
     }
 
@@ -289,14 +286,14 @@ mod tests {
 
     #[derive(Clone)]
     struct MockRemote {
-        task_tx: mpsc::SyncSender<TaskCell<MockRemote, ()>>,
+        task_tx: mpsc::SyncSender<TaskCell<MockRemote>>,
     }
 
     impl LocalSpawn for MockLocal {
-        type TaskCell = TaskCell<MockRemote, ()>;
+        type TaskCell = TaskCell<MockRemote>;
         type Remote = MockRemote;
 
-        fn spawn(&mut self, task_cell: TaskCell<MockRemote, ()>) {
+        fn spawn(&mut self, task_cell: TaskCell<MockRemote>) {
             self.remote.task_tx.send(task_cell).unwrap();
         }
 
@@ -306,9 +303,9 @@ mod tests {
     }
 
     impl RemoteSpawn for MockRemote {
-        type TaskCell = TaskCell<MockRemote, ()>;
+        type TaskCell = TaskCell<MockRemote>;
 
-        fn spawn(&self, task_cell: TaskCell<MockRemote, ()>) {
+        fn spawn(&self, task_cell: TaskCell<MockRemote>) {
             self.task_tx.send(task_cell).unwrap();
         }
     }
@@ -352,7 +349,7 @@ mod tests {
             WakeLater::new(waker_tx.clone()).await;
             res_tx.send(2).unwrap();
         };
-        local.spawn(TaskCell::new(fut, local.remote(), ()));
+        local.spawn(TaskCell::new(fut, local.remote(), Default::default()));
 
         local.handle_once();
         assert_eq!(res_rx.recv().unwrap(), 1);
@@ -413,7 +410,7 @@ mod tests {
             PendingOnce::new().await;
             res_tx.send(2).unwrap();
         };
-        local.spawn(TaskCell::new(fut, local.remote(), ()));
+        local.spawn(TaskCell::new(fut, local.remote(), Default::default()));
 
         local.handle_once();
         assert_eq!(res_rx.recv().unwrap(), 1);
@@ -434,7 +431,7 @@ mod tests {
             PendingOnce::new().await;
             res_tx.send(4).unwrap();
         };
-        local.spawn(TaskCell::new(fut, local.remote(), ()));
+        local.spawn(TaskCell::new(fut, local.remote(), Default::default()));
 
         local.handle_once();
         assert_eq!(res_rx.recv().unwrap(), 1);


### PR DESCRIPTION
Due to limitation of rust-lang/rust#35978, using generic requires trait
object or redundant verbose struct wrapper to work. So this PR uses enum
instead to get around the problem and make the types simpler.