### PR TITLE
pool: fix ordering issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ repository = "https://github.com/tikv/yatp/"
 num_cpus = "1.0"
 parking_lot_core = "0.7"
 crossbeam-deque = "0.7"
-rand = { version = "0.7", features = ["small_rng"] }
+rand = "0.7"

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -52,7 +52,7 @@ impl<T> QueueCore<T> {
     /// If the method is going to wake up any threads, source is used to trace who triggers
     /// the action.
     pub fn ensure_workers(&self, source: usize) {
-        let cnt = self.active_workers.load(Ordering::Relaxed);
+        let cnt = self.active_workers.load(Ordering::SeqCst);
         if (cnt >> WORKER_COUNT_SHIFT) >= self.config.max_thread_count || is_shutdown(cnt) {
             return;
         }


### PR DESCRIPTION
loom shows that load and store can be reordered when using relax order,
so change it to SeqCst instead.