### PR TITLE
*: make spawn easier

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -14,7 +14,7 @@ pub use self::builder::{Builder, SchedConfig};
 pub use self::runner::{CloneRunnerBuilder, Runner, RunnerBuilder};
 pub use self::spawn::{build_spawn, Local, Remote};
 
-use crate::queue::TaskCell;
+use crate::queue::{TaskCell, WithExtras};
 use std::mem;
 use std::sync::Mutex;
 use std::thread::JoinHandle;
@@ -29,7 +29,7 @@ impl<T: TaskCell + Send> ThreadPool<T> {
     /// Spawns the task into the thread pool.
     ///
     /// If the pool is shutdown, it becomes no-op.
-    pub fn spawn(&self, t: impl Into<T>) {
+    pub fn spawn(&self, t: impl WithExtras<T>) {
         self.remote.spawn(t);
     }
 

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -5,7 +5,7 @@
 //! tasks waiting to be handled.
 
 use crate::pool::SchedConfig;
-use crate::queue::{LocalQueue, Pop, TaskCell, WithExtras, Extras, TaskInjector};
+use crate::queue::{Extras, LocalQueue, Pop, TaskCell, TaskInjector, WithExtras};
 use parking_lot_core::{ParkResult, ParkToken, UnparkToken};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -260,17 +260,14 @@ impl<T: TaskCell + Send> Local<T> {
 /// This is only for tests purpose so that a thread pool doesn't have to be
 /// spawned to test a Runner.
 pub fn build_spawn<T>(
-    builder: Option<crate::queue::multilevel::Builder>,
+    queue_type: impl Into<crate::queue::QueueType>,
     config: SchedConfig,
 ) -> (Remote<T>, Vec<Local<T>>)
 where
     T: TaskCell + Send,
 {
-    let (global, locals) = if let Some(builder) = builder {
-        builder.build(config.max_thread_count)
-    } else {
-        crate::queue::single_level(config.max_thread_count)
-    };
+    let queue_type = queue_type.into();
+    let (global, locals) = crate::queue::build(queue_type, config.max_thread_count);
     let core = Arc::new(QueueCore::new(global, config));
     let l = locals
         .into_iter()

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -5,7 +5,7 @@
 //! tasks waiting to be handled.
 
 use crate::pool::SchedConfig;
-use crate::queue::{LocalQueue, Pop, TaskCell, TaskInjector};
+use crate::queue::{LocalQueue, Pop, TaskCell, WithExtras, Extras, TaskInjector};
 use parking_lot_core::{ParkResult, ParkToken, UnparkToken};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -127,6 +127,10 @@ impl<T: TaskCell + Send> QueueCore<T> {
         self.global_queue.push(task);
         self.ensure_workers(source);
     }
+
+    fn default_extras(&self) -> Extras {
+        self.global_queue.default_extras()
+    }
 }
 
 /// Submits tasks to associated thread pool.
@@ -143,8 +147,9 @@ impl<T: TaskCell + Send> Remote<T> {
     }
 
     /// Submits a task to the thread pool.
-    pub fn spawn(&self, task: impl Into<T>) {
-        self.core.push(0, task.into());
+    pub fn spawn(&self, task: impl WithExtras<T>) {
+        let t = task.with_extras(|| self.core.default_extras());
+        self.core.push(0, t);
     }
 
     pub(crate) fn stop(&self) {
@@ -189,13 +194,15 @@ impl<T: TaskCell + Send> Local<T> {
     }
 
     /// Spawns a task to the local queue.
-    pub fn spawn(&mut self, task: T) {
-        self.local_queue.push(task);
+    pub fn spawn(&mut self, task: impl WithExtras<T>) {
+        let t = task.with_extras(|| self.local_queue.default_extras());
+        self.local_queue.push(t);
     }
 
     /// Spawns a task to the remote queue.
-    pub fn spawn_remote(&self, task: T) {
-        self.core.push(self.id, task);
+    pub fn spawn_remote(&self, task: impl WithExtras<T>) {
+        let t = task.with_extras(|| self.local_queue.default_extras());
+        self.core.push(self.id, t);
     }
 
     /// Gets a remote so that tasks can be spawned from other threads.

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -55,7 +55,6 @@ where
 mod tests {
     use super::*;
     use crate::pool::spawn::*;
-    use crate::queue::*;
     use crate::task::callback;
     use std::sync::*;
     use std::time::*;
@@ -121,7 +120,7 @@ mod tests {
         };
         let metrics = r.metrics.clone();
         let mut expected_metrics = Metrics::default();
-        let (injector, mut locals) = build_spawn(single_level, Default::default());
+        let (injector, mut locals) = build_spawn(None, Default::default());
         let th = WorkerThread::new(locals.remove(0), r);
         let handle = std::thread::spawn(move || {
             th.run();

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -55,6 +55,7 @@ where
 mod tests {
     use super::*;
     use crate::pool::spawn::*;
+    use crate::queue::QueueType;
     use crate::task::callback;
     use std::sync::*;
     use std::time::*;
@@ -120,7 +121,7 @@ mod tests {
         };
         let metrics = r.metrics.clone();
         let mut expected_metrics = Metrics::default();
-        let (injector, mut locals) = build_spawn(None, Default::default());
+        let (injector, mut locals) = build_spawn(QueueType::SingleLevel, Default::default());
         let th = WorkerThread::new(locals.remove(0), r);
         let handle = std::thread::spawn(move || {
             th.run();

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -37,7 +37,7 @@ impl<F: TaskCell> WithExtras<F> for F {
 }
 
 /// The injector of a task queue.
-pub struct TaskInjector<T>(InjectorInner<T>);
+pub(crate) struct TaskInjector<T>(InjectorInner<T>);
 
 enum InjectorInner<T> {
     SingleLevel(single_level::TaskInjector<T>),
@@ -75,7 +75,7 @@ pub struct Pop<T> {
 }
 
 /// The local queue of a task queue.
-pub struct LocalQueue<T>(LocalQueueInner<T>);
+pub(crate) struct LocalQueue<T>(LocalQueueInner<T>);
 
 enum LocalQueueInner<T> {
     SingleLevel(single_level::LocalQueue<T>),
@@ -109,7 +109,7 @@ impl<T: TaskCell + Send> LocalQueue<T> {
 }
 
 /// Creates a task queue that allows given number consumers.
-pub fn single_level<T>(local_num: usize) -> (TaskInjector<T>, Vec<LocalQueue<T>>) {
+pub(crate) fn single_level<T>(local_num: usize) -> (TaskInjector<T>, Vec<LocalQueue<T>>) {
     let (injector, locals) = single_level::create(local_num);
     (
         TaskInjector(InjectorInner::SingleLevel(injector)),

--- a/src/queue/multilevel.rs
+++ b/src/queue/multilevel.rs
@@ -770,7 +770,7 @@ mod tests {
         let builder = Builder::new(Config::default());
         let mut runner_builder = builder.runner_builder(MockRunnerBuilder);
         let manager = builder.manager.clone();
-        let (remote, mut locals) = build_spawn(Some(builder), Default::default());
+        let (remote, mut locals) = build_spawn(builder, Default::default());
         let mut runner = runner_builder.build();
 
         remote.spawn(MockTask::new(100, Extras::new_multilevel(1, None)));

--- a/src/queue/multilevel.rs
+++ b/src/queue/multilevel.rs
@@ -42,7 +42,7 @@ const MAX_LEVEL0_CHANCE: u32 = 4_209_067_949; // 0.98
 const ADJUST_AMOUNT: u32 = (MAX_LEVEL0_CHANCE - MIN_LEVEL0_CHANCE) / 8; // 0.06
 
 /// The injector of a multilevel task queue.
-pub struct TaskInjector<T> {
+pub(crate) struct TaskInjector<T> {
     level_injectors: Arc<[Injector<T>; LEVEL_NUM]>,
     manager: Arc<LevelManager>,
 }
@@ -68,7 +68,7 @@ where
 }
 
 /// The local queue of a multilevel task queue.
-pub struct LocalQueue<T> {
+pub(crate) struct LocalQueue<T> {
     local_queue: Worker<T>,
     level_injectors: Arc<[Injector<T>; LEVEL_NUM]>,
     stealers: Vec<Stealer<T>>,
@@ -497,7 +497,10 @@ impl Builder {
     }
 
     /// Creates the injector and local queues of the multilevel task queue.
-    pub fn build<T>(self, local_num: usize) -> (super::TaskInjector<T>, Vec<super::LocalQueue<T>>) {
+    pub(crate) fn build<T>(
+        self,
+        local_num: usize,
+    ) -> (super::TaskInjector<T>, Vec<super::LocalQueue<T>>) {
         let (injector, locals) = self.build_raw(local_num);
         let local_queues = locals
             .into_iter()
@@ -767,10 +770,7 @@ mod tests {
         let builder = Builder::new(Config::default());
         let mut runner_builder = builder.runner_builder(MockRunnerBuilder);
         let manager = builder.manager.clone();
-        let (remote, mut locals) = build_spawn(
-            move |local_num| builder.build(local_num),
-            Default::default(),
-        );
+        let (remote, mut locals) = build_spawn(Some(builder), Default::default());
         let mut runner = runner_builder.build();
 
         remote.spawn(MockTask::new(100, Extras::new_multilevel(1, None)));

--- a/src/task/callback.rs
+++ b/src/task/callback.rs
@@ -157,11 +157,12 @@ impl crate::pool::Runner for Runner {
 mod tests {
     use super::*;
     use crate::pool::{build_spawn, Runner as _};
+    use crate::queue::QueueType;
     use std::sync::mpsc;
 
     #[test]
     fn test_once() {
-        let (_, mut locals) = build_spawn(None, Default::default());
+        let (_, mut locals) = build_spawn(QueueType::SingleLevel, Default::default());
         let mut runner = Runner::default();
         let (tx, rx) = mpsc::channel();
         runner.handle(
@@ -178,7 +179,7 @@ mod tests {
 
     #[test]
     fn test_mut_no_respawn() {
-        let (_, mut locals) = build_spawn(None, Default::default());
+        let (_, mut locals) = build_spawn(QueueType::SingleLevel, Default::default());
         let mut runner = Runner::new(1);
         let (tx, rx) = mpsc::channel();
 
@@ -204,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_mut_respawn() {
-        let (_, mut locals) = build_spawn(None, Default::default());
+        let (_, mut locals) = build_spawn(QueueType::SingleLevel, Default::default());
         let mut runner = Runner::new(1);
         let (tx, rx) = mpsc::channel();
 

--- a/src/task/callback.rs
+++ b/src/task/callback.rs
@@ -39,7 +39,7 @@ impl crate::queue::TaskCell for TaskCell {
     }
 }
 
-impl<F> WithExtras<TaskCell> for F 
+impl<F> WithExtras<TaskCell> for F
 where
     F: FnOnce(&mut Handle<'_>) + Send + 'static,
 {

--- a/src/task/callback.rs
+++ b/src/task/callback.rs
@@ -157,12 +157,11 @@ impl crate::pool::Runner for Runner {
 mod tests {
     use super::*;
     use crate::pool::{build_spawn, Runner as _};
-    use crate::queue;
     use std::sync::mpsc;
 
     #[test]
     fn test_once() {
-        let (_, mut locals) = build_spawn(queue::single_level, Default::default());
+        let (_, mut locals) = build_spawn(None, Default::default());
         let mut runner = Runner::default();
         let (tx, rx) = mpsc::channel();
         runner.handle(
@@ -179,7 +178,7 @@ mod tests {
 
     #[test]
     fn test_mut_no_respawn() {
-        let (_, mut locals) = build_spawn(queue::single_level, Default::default());
+        let (_, mut locals) = build_spawn(None, Default::default());
         let mut runner = Runner::new(1);
         let (tx, rx) = mpsc::channel();
 
@@ -205,7 +204,7 @@ mod tests {
 
     #[test]
     fn test_mut_respawn() {
-        let (_, mut locals) = build_spawn(queue::single_level, Default::default());
+        let (_, mut locals) = build_spawn(None, Default::default());
         let mut runner = Runner::new(1);
         let (tx, rx) = mpsc::channel();
 

--- a/src/task/callback.rs
+++ b/src/task/callback.rs
@@ -3,7 +3,7 @@
 //! A [`FnOnce`] or [`FnMut`] closure.
 
 use crate::pool::Local;
-use crate::queue::Extras;
+use crate::queue::{Extras, WithExtras};
 
 /// A callback task, which is either a [`FnOnce`] or a [`FnMut`].
 pub enum Task {
@@ -39,14 +39,14 @@ impl crate::queue::TaskCell for TaskCell {
     }
 }
 
-impl<F> From<F> for TaskCell
+impl<F> WithExtras<TaskCell> for F 
 where
     F: FnOnce(&mut Handle<'_>) + Send + 'static,
 {
-    fn from(f: F) -> TaskCell {
+    fn with_extras(self, extras: impl FnOnce() -> Extras) -> TaskCell {
         TaskCell {
-            task: Task::new_once(f),
-            extras: Extras::single_level(),
+            task: Task::new_once(self),
+            extras: extras(),
         }
     }
 }

--- a/src/task/future.rs
+++ b/src/task/future.rs
@@ -314,7 +314,6 @@ impl Future for Reschedule {
 mod tests {
     use super::*;
     use crate::pool::{build_spawn, Runner as _};
-    use crate::queue;
 
     use std::cell::RefCell;
     use std::rc::Rc;
@@ -328,7 +327,7 @@ mod tests {
 
     impl MockLocal {
         fn new(runner: Runner) -> MockLocal {
-            let (remote, locals) = build_spawn(queue::single_level, Default::default());
+            let (remote, locals) = build_spawn(None, Default::default());
             MockLocal {
                 runner: Rc::new(RefCell::new(runner)),
                 remote,

--- a/src/task/future.rs
+++ b/src/task/future.rs
@@ -314,6 +314,7 @@ impl Future for Reschedule {
 mod tests {
     use super::*;
     use crate::pool::{build_spawn, Runner as _};
+    use crate::queue::QueueType;
 
     use std::cell::RefCell;
     use std::rc::Rc;
@@ -327,7 +328,7 @@ mod tests {
 
     impl MockLocal {
         fn new(runner: Runner) -> MockLocal {
-            let (remote, locals) = build_spawn(None, Default::default());
+            let (remote, locals) = build_spawn(QueueType::SingleLevel, Default::default());
             MockLocal {
                 runner: Rc::new(RefCell::new(runner)),
                 remote,

--- a/src/task/future.rs
+++ b/src/task/future.rs
@@ -389,9 +389,7 @@ mod tests {
             WakeLater::new(waker_tx.clone()).await;
             res_tx.send(2).unwrap();
         };
-        local
-            .remote
-            .spawn(TaskCell::new(fut, Extras::single_level()));
+        local.remote.spawn(fut);
 
         local.handle_once();
         assert_eq!(res_rx.recv().unwrap(), 1);
@@ -452,9 +450,7 @@ mod tests {
             PendingOnce::new().await;
             res_tx.send(2).unwrap();
         };
-        local
-            .remote
-            .spawn(TaskCell::new(fut, Extras::single_level()));
+        local.remote.spawn(fut);
 
         local.handle_once();
         assert_eq!(res_rx.recv().unwrap(), 1);
@@ -475,9 +471,7 @@ mod tests {
             PendingOnce::new().await;
             res_tx.send(4).unwrap();
         };
-        local
-            .remote
-            .spawn(TaskCell::new(fut, Extras::single_level()));
+        local.remote.spawn(fut);
 
         local.handle_once();
         assert_eq!(res_rx.recv().unwrap(), 1);
@@ -501,9 +495,7 @@ mod tests {
             PendingOnce::new().await;
             res_tx.send(3).unwrap();
         };
-        local
-            .remote
-            .spawn(TaskCell::new(fut, Extras::single_level()));
+        local.remote.spawn(fut);
 
         local.handle_once();
         assert_eq!(res_rx.recv().unwrap(), 1);


### PR DESCRIPTION
This PR adds a new trait `WithExtras` to make spawn easier. Now spawning futures with default extras in future pool can be as simple as
```
pool.spawn(f);
```
rather than in the past
```
pool.spawn(TaskCell::new(f, queue::extras()));
```
.

The old way is not removed as user may want to provide a custom extras.

This PR also make the queue types private. Those types can only be used when constructing pool, it's meaningless and distracting to expose the full type.