### PR TITLE
*: add benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,28 @@ parking_lot_core = "0.7"
 crossbeam-deque = "0.7"
 dashmap = "1.2.0"
 rand = "0.7"
+
+[dev-dependencies]
+criterion = "*"
+tokio = { version = "0.2.0", features = ["sync", "rt-threaded"] }
+async-std = "1.0"
+threadpool = "1.0"
+
+[[bench]]
+name = "spawn_many"
+harness = false
+
+[[bench]]
+name = "yield_many"
+harness = false
+
+[[bench]]
+name = "chained_spawn"
+harness = false
+
+[[bench]]
+name = "ping_pong"
+harness = false
+
+[profile.bench]
+codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ dashmap = "1.2.0"
 rand = "0.7"
 
 [dev-dependencies]
-criterion = "*"
+criterion = "0.3"
 tokio = { version = "0.2.0", features = ["sync", "rt-threaded"] }
 async-std = "1.0"
 threadpool = "1.0"

--- a/benches/chained_spawn.rs
+++ b/benches/chained_spawn.rs
@@ -1,0 +1,156 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use criterion::*;
+
+mod yatp_callback {
+    use criterion::*;
+    use std::sync::mpsc;
+    use yatp::task::callback::Handle;
+
+    pub fn chained_spawn(b: &mut Bencher<'_>, iter_count: usize) {
+        let pool = yatp::Builder::new("chained_spawn").build_callback_pool();
+
+        fn iter(handle: &mut Handle<'_>, done_tx: mpsc::SyncSender<()>, n: usize) {
+            if n == 0 {
+                done_tx.send(()).unwrap();
+            } else {
+                handle.spawn(move |h: &mut Handle<'_>| {
+                    iter(h, done_tx, n - 1);
+                })
+            }
+        }
+
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
+
+        b.iter(move || {
+            let done_tx = done_tx.clone();
+            pool.spawn(move |h: &mut Handle<'_>| {
+                iter(h, done_tx, iter_count);
+            });
+
+            done_rx.recv().unwrap();
+        });
+    }
+}
+
+mod yatp_future {
+    use criterion::*;
+    use std::sync::mpsc;
+    use yatp::task::future::TaskCell;
+    use yatp::Remote;
+
+    pub fn chained_spawn(b: &mut Bencher<'_>, iter_count: usize) {
+        let pool = yatp::Builder::new("chained_spawn").build_future_pool();
+
+        fn iter(remote: Remote<TaskCell>, done_tx: mpsc::SyncSender<()>, n: usize) {
+            if n == 0 {
+                done_tx.send(()).unwrap();
+            } else {
+                let s2 = remote.clone();
+                remote.spawn(async move {
+                    iter(s2, done_tx, n - 1);
+                });
+            }
+        }
+
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
+
+        b.iter(move || {
+            let done_tx = done_tx.clone();
+            let remote = pool.remote().clone();
+            pool.spawn(async move {
+                iter(remote, done_tx, iter_count);
+            });
+
+            done_rx.recv().unwrap();
+        });
+    }
+}
+
+mod tokio {
+    use criterion::*;
+    use std::sync::mpsc;
+    use tokio::runtime::*;
+
+    pub fn chained_spawn(b: &mut Bencher<'_>, iter_count: usize) {
+        let pool = Builder::new()
+            .threaded_scheduler()
+            .core_threads(num_cpus::get())
+            .build()
+            .unwrap();
+
+        fn iter(handle: Handle, done_tx: mpsc::SyncSender<()>, n: usize) {
+            if n == 0 {
+                done_tx.send(()).unwrap();
+            } else {
+                let s2 = handle.clone();
+                handle.spawn(async move {
+                    iter(s2, done_tx, n - 1);
+                });
+            }
+        }
+
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
+
+        b.iter(move || {
+            let done_tx = done_tx.clone();
+            let handle = pool.handle().clone();
+            pool.spawn(async move {
+                iter(handle, done_tx, iter_count);
+            });
+
+            done_rx.recv().unwrap();
+        });
+    }
+}
+
+mod async_std {
+    use criterion::*;
+    use std::sync::mpsc;
+
+    pub fn chained_spawn(b: &mut Bencher, iter_count: usize) {
+        fn iter(done_tx: mpsc::SyncSender<()>, n: usize) {
+            if n == 0 {
+                done_tx.send(()).unwrap();
+            } else {
+                async_std::task::spawn(async move {
+                    iter(done_tx, n - 1);
+                });
+            }
+        }
+
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
+
+        b.iter(move || {
+            let done_tx = done_tx.clone();
+            async_std::task::spawn(async move {
+                iter(done_tx, iter_count);
+            });
+
+            done_rx.recv().unwrap();
+        });
+    }
+}
+
+pub fn chained_spawn(b: &mut Criterion) {
+    let mut group = b.benchmark_group("chained_spawn");
+    for i in &[100, 400, 700, 1000] {
+        group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
+            yatp_future::chained_spawn(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("yatp::callback", i), i, |b, i| {
+            yatp_callback::chained_spawn(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("tokio", i), i, |b, i| {
+            tokio::chained_spawn(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("async-std", i), i, |b, i| {
+            async_std::chained_spawn(b, *i)
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(chained_spawn_group, chained_spawn);
+
+criterion_main!(chained_spawn_group);

--- a/benches/ping_pong.rs
+++ b/benches/ping_pong.rs
@@ -1,0 +1,221 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use criterion::*;
+
+mod yatp_callback {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+    use yatp::task::callback::Handle;
+
+    pub fn ping_pong(b: &mut Bencher<'_>, ping_count: usize) {
+        let pool = yatp::Builder::new("ping_pong").build_callback_pool();
+
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+
+        b.iter(|| {
+            let done_tx = done_tx.clone();
+            let rem = rem.clone();
+            rem.store(ping_count, Ordering::Relaxed);
+
+            pool.spawn(move |h: &mut Handle<'_>| {
+                for _ in 0..ping_count {
+                    let rem = rem.clone();
+                    let done_tx = done_tx.clone();
+
+                    h.spawn(move |h: &mut Handle<'_>| {
+                        let (tx1, rx1) = mpsc::channel();
+                        let (tx2, rx2) = mpsc::channel();
+
+                        tx1.send(()).unwrap();
+                        h.spawn(move |h: &mut Handle<'_>| {
+                            rx1.recv().unwrap();
+                            tx2.send(()).unwrap();
+                            h.spawn(move |_: &mut Handle<'_>| {
+                                rx2.recv().unwrap();
+                                if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                                    done_tx.send(()).unwrap();
+                                }
+                            })
+                        })
+                    });
+                }
+            });
+
+            done_rx.recv().unwrap();
+        });
+    }
+}
+
+mod yatp_future {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+    use tokio::sync::oneshot;
+
+    pub fn ping_pong(b: &mut Bencher<'_>, ping_count: usize) {
+        let pool = yatp::Builder::new("ping_pong").build_future_pool();
+
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+
+        b.iter(|| {
+            let done_tx = done_tx.clone();
+            let rem = rem.clone();
+            rem.store(ping_count, Ordering::Relaxed);
+
+            let remote = pool.remote().clone();
+
+            pool.spawn(async move {
+                for _ in 0..ping_count {
+                    let rem = rem.clone();
+                    let done_tx = done_tx.clone();
+
+                    let remote2 = remote.clone();
+
+                    remote.spawn(async move {
+                        let (tx1, rx1) = oneshot::channel();
+                        let (tx2, rx2) = oneshot::channel();
+
+                        remote2.spawn(async move {
+                            rx1.await.unwrap();
+                            tx2.send(()).unwrap();
+                        });
+
+                        tx1.send(()).unwrap();
+                        rx2.await.unwrap();
+
+                        if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                            done_tx.send(()).unwrap();
+                        }
+                    });
+                }
+            });
+
+            done_rx.recv().unwrap();
+        });
+    }
+}
+
+mod tokio {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+    use tokio::runtime::Builder;
+    use tokio::sync::oneshot;
+
+    pub fn ping_pong(b: &mut Bencher<'_>, ping_count: usize) {
+        let pool = Builder::new()
+            .threaded_scheduler()
+            .core_threads(num_cpus::get())
+            .build()
+            .unwrap();
+
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+
+        b.iter(|| {
+            let done_tx = done_tx.clone();
+            let rem = rem.clone();
+            rem.store(ping_count, Ordering::Relaxed);
+
+            let handle = pool.handle().clone();
+
+            pool.spawn(async move {
+                for _ in 0..ping_count {
+                    let rem = rem.clone();
+                    let done_tx = done_tx.clone();
+
+                    let handle2 = handle.clone();
+
+                    handle.spawn(async move {
+                        let (tx1, rx1) = oneshot::channel();
+                        let (tx2, rx2) = oneshot::channel();
+
+                        handle2.spawn(async move {
+                            rx1.await.unwrap();
+                            tx2.send(()).unwrap();
+                        });
+
+                        tx1.send(()).unwrap();
+                        rx2.await.unwrap();
+
+                        if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                            done_tx.send(()).unwrap();
+                        }
+                    });
+                }
+            });
+
+            done_rx.recv().unwrap();
+        });
+    }
+}
+
+mod async_std {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+    use tokio::sync::oneshot;
+
+    pub fn ping_pong(b: &mut Bencher<'_>, ping_count: usize) {
+        let (done_tx, done_rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+
+        b.iter(|| {
+            let done_tx = done_tx.clone();
+            let rem = rem.clone();
+            rem.store(ping_count, Ordering::Relaxed);
+
+            async_std::task::spawn(async move {
+                for _ in 0..ping_count {
+                    let rem = rem.clone();
+                    let done_tx = done_tx.clone();
+
+                    async_std::task::spawn(async move {
+                        let (tx1, rx1) = oneshot::channel();
+                        let (tx2, rx2) = oneshot::channel();
+
+                        async_std::task::spawn(async move {
+                            rx1.await.unwrap();
+                            tx2.send(()).unwrap();
+                        });
+
+                        tx1.send(()).unwrap();
+                        rx2.await.unwrap();
+
+                        if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                            done_tx.send(()).unwrap();
+                        }
+                    });
+                }
+            });
+
+            done_rx.recv().unwrap();
+        });
+    }
+}
+
+pub fn ping_pong(b: &mut Criterion) {
+    let mut group = b.benchmark_group("ping_pong");
+    for i in &[100, 400, 700, 1000] {
+        group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
+            yatp_future::ping_pong(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("yatp::callback", i), i, |b, i| {
+            yatp_callback::ping_pong(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("tokio", i), i, |b, i| {
+            tokio::ping_pong(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("async-std", i), i, |b, i| {
+            async_std::ping_pong(b, *i)
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(ping_pong_group, ping_pong);
+
+criterion_main!(ping_pong_group);

--- a/benches/spawn_many.rs
+++ b/benches/spawn_many.rs
@@ -1,0 +1,178 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use criterion::*;
+
+mod yatp_callback {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+
+    pub fn spawn_many(b: &mut Bencher<'_>, spawn_count: usize) {
+        let (tx, rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+        let pool = yatp::Builder::new("spawn_many").build_callback_pool();
+
+        b.iter(|| {
+            rem.store(spawn_count, Ordering::Relaxed);
+
+            for _ in 0..spawn_count {
+                let tx = tx.clone();
+                let rem = rem.clone();
+
+                pool.spawn(move |_: &mut yatp::task::callback::Handle<'_>| {
+                    if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                        tx.send(()).unwrap();
+                    }
+                });
+            }
+
+            let _ = rx.recv().unwrap();
+        });
+    }
+}
+
+mod yatp_future {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+
+    pub fn spawn_many(b: &mut Bencher<'_>, spawn_count: usize) {
+        let (tx, rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+        let pool = yatp::Builder::new("spawn_many").build_future_pool();
+
+        b.iter(|| {
+            rem.store(spawn_count, Ordering::Relaxed);
+
+            for _ in 0..spawn_count {
+                let tx = tx.clone();
+                let rem = rem.clone();
+
+                pool.spawn(async move {
+                    if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                        tx.send(()).unwrap();
+                    }
+                });
+            }
+
+            let _ = rx.recv().unwrap();
+        });
+    }
+}
+
+mod threadpool {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+
+    pub fn spawn_many(b: &mut Bencher<'_>, spawn_count: usize) {
+        let (tx, rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+        let pool = threadpool::ThreadPool::new(num_cpus::get());
+
+        b.iter(|| {
+            rem.store(spawn_count, Ordering::Relaxed);
+
+            for _ in 0..spawn_count {
+                let tx = tx.clone();
+                let rem = rem.clone();
+
+                pool.execute(move || {
+                    if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                        tx.send(()).unwrap();
+                    }
+                });
+            }
+
+            let _ = rx.recv().unwrap();
+        });
+    }
+}
+
+mod tokio {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+    use tokio::runtime::Builder;
+
+    pub fn spawn_many(b: &mut Bencher<'_>, spawn_count: usize) {
+        let (tx, rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+        let pool = Builder::new()
+            .threaded_scheduler()
+            .core_threads(num_cpus::get())
+            .build()
+            .unwrap();
+
+        b.iter(|| {
+            rem.store(spawn_count, Ordering::Relaxed);
+
+            for _ in 0..spawn_count {
+                let tx = tx.clone();
+                let rem = rem.clone();
+
+                pool.spawn(async move {
+                    if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                        tx.send(()).unwrap();
+                    }
+                });
+            }
+
+            let _ = rx.recv().unwrap();
+        });
+    }
+}
+
+mod async_std {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+
+    pub fn spawn_many(b: &mut Bencher<'_>, spawn_count: usize) {
+        let (tx, rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+
+        b.iter(|| {
+            rem.store(spawn_count, Ordering::Relaxed);
+
+            for _ in 0..spawn_count {
+                let tx = tx.clone();
+                let rem = rem.clone();
+
+                async_std::task::spawn(async move {
+                    if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                        tx.send(()).unwrap();
+                    }
+                });
+            }
+
+            let _ = rx.recv().unwrap();
+        });
+    }
+}
+
+pub fn spawn_many(b: &mut Criterion) {
+    let mut group = b.benchmark_group("spawn_many");
+    for i in &[1000, 4000, 7000, 10000] {
+        group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
+            yatp_future::spawn_many(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("yatp::callback", i), i, |b, i| {
+            yatp_callback::spawn_many(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("threadpool", i), i, |b, i| {
+            threadpool::spawn_many(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("tokio", i), i, |b, i| {
+            tokio::spawn_many(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("async-std", i), i, |b, i| {
+            async_std::spawn_many(b, *i)
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(spawn_many_group, spawn_many);
+
+criterion_main!(spawn_many_group);

--- a/benches/yield_many.rs
+++ b/benches/yield_many.rs
@@ -1,0 +1,168 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use criterion::*;
+use std::future::*;
+use std::pin::Pin;
+use std::task::*;
+
+const TASKS_PER_CPU: usize = 50;
+
+struct Backoff(usize);
+
+impl Future for Backoff {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.0 == 0 {
+            Poll::Ready(())
+        } else {
+            self.0 -= 1;
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
+mod yatp_callback {
+    use criterion::*;
+    use std::sync::mpsc;
+    use yatp::queue::*;
+    use yatp::task::callback::{Task, TaskCell};
+
+    pub fn yield_many(b: &mut Bencher<'_>, yield_count: usize) {
+        let tasks = super::TASKS_PER_CPU * num_cpus::get();
+        let (tx, rx) = mpsc::sync_channel(tasks);
+        let pool = yatp::Builder::new("yield_many").build_callback_pool();
+
+        b.iter(move || {
+            for _ in 0..tasks {
+                let tx = tx.clone();
+                let mut num_yield = yield_count;
+
+                pool.spawn(TaskCell {
+                    task: Task::new_mut(move |h: &mut yatp::task::callback::Handle<'_>| {
+                        if num_yield == 0 {
+                            tx.send(()).unwrap();
+                        } else {
+                            num_yield -= 1;
+                            h.set_rerun(true);
+                        }
+                    }),
+                    extras: Extras::single_level(),
+                });
+            }
+
+            for _ in 0..tasks {
+                let _ = rx.recv().unwrap();
+            }
+        });
+    }
+}
+
+mod yatp_future {
+    use criterion::*;
+    use std::sync::mpsc;
+
+    pub fn yield_many(b: &mut Bencher<'_>, yield_count: usize) {
+        let tasks = super::TASKS_PER_CPU * num_cpus::get();
+        let (tx, rx) = mpsc::sync_channel(tasks);
+        let pool = yatp::Builder::new("yield_many").build_future_pool();
+
+        b.iter(move || {
+            for _ in 0..tasks {
+                let tx = tx.clone();
+
+                pool.spawn(async move {
+                    let backoff = super::Backoff(yield_count);
+                    backoff.await;
+                    tx.send(()).unwrap();
+                });
+            }
+
+            for _ in 0..tasks {
+                let _ = rx.recv().unwrap();
+            }
+        });
+    }
+}
+
+mod tokio {
+    use criterion::*;
+    use std::sync::mpsc;
+    use tokio::runtime::*;
+
+    pub fn yield_many(b: &mut Bencher<'_>, yield_count: usize) {
+        let tasks = super::TASKS_PER_CPU * num_cpus::get();
+        let (tx, rx) = mpsc::sync_channel(tasks);
+        let pool = Builder::new()
+            .threaded_scheduler()
+            .core_threads(num_cpus::get())
+            .build()
+            .unwrap();
+
+        b.iter(move || {
+            for _ in 0..tasks {
+                let tx = tx.clone();
+
+                pool.spawn(async move {
+                    let backoff = super::Backoff(yield_count);
+                    backoff.await;
+                    tx.send(()).unwrap();
+                });
+            }
+
+            for _ in 0..tasks {
+                let _ = rx.recv().unwrap();
+            }
+        });
+    }
+}
+
+mod async_std {
+    use criterion::*;
+    use std::sync::mpsc;
+
+    pub fn yield_many(b: &mut Bencher<'_>, yield_count: usize) {
+        let tasks = super::TASKS_PER_CPU * num_cpus::get();
+        let (tx, rx) = mpsc::sync_channel(tasks);
+
+        b.iter(move || {
+            for _ in 0..tasks {
+                let tx = tx.clone();
+
+                async_std::task::spawn(async move {
+                    let backoff = super::Backoff(yield_count);
+                    backoff.await;
+                    tx.send(()).unwrap();
+                });
+            }
+
+            for _ in 0..tasks {
+                let _ = rx.recv().unwrap();
+            }
+        });
+    }
+}
+
+pub fn yield_many(b: &mut Criterion) {
+    let mut group = b.benchmark_group("yield_many");
+    for i in &[100, 400, 700, 1000] {
+        group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
+            yatp_future::yield_many(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("yatp::callback", i), i, |b, i| {
+            yatp_callback::yield_many(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("tokio", i), i, |b, i| {
+            tokio::yield_many(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("async-std", i), i, |b, i| {
+            async_std::yield_many(b, *i)
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(yield_many_group, yield_many);
+
+criterion_main!(yield_many_group);

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -45,8 +45,8 @@ impl<T: TaskCell + Send> ThreadPool<T> {
     }
 
     /// Get a remote queue for spawning tasks without owning the thread pool.
-    pub fn remote(&self) -> Remote<T> {
-        self.remote.clone()
+    pub fn remote(&self) -> &Remote<T> {
+        &self.remote
     }
 }
 

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -228,7 +228,7 @@ impl Builder {
     /// Spawns a future pool.
     ///
     /// It setups the pool with single level queue.
-    pub fn build_future_pool<T, B>(&self) -> ThreadPool<future::TaskCell> {
+    pub fn build_future_pool(&self) -> ThreadPool<future::TaskCell> {
         let fb = CloneRunnerBuilder(future::Runner::default());
         self.build_with_queue_and_runner(QueueType::SingleLevel, fb)
     }

--- a/src/task/callback.rs
+++ b/src/task/callback.rs
@@ -77,6 +77,11 @@ impl<'a> Handle<'a> {
         });
     }
 
+    /// Spawns a task to the thread pool.
+    pub fn spawn(&mut self, t: impl WithExtras<TaskCell>) {
+        self.local.spawn(t)
+    }
+
     /// Sets whether this task should be rerun later.
     pub fn set_rerun(&mut self, rerun: bool) {
         self.rerun = rerun;


### PR DESCRIPTION
The PR introduces four benchmark cases and compare them with tokio,
threadpool and async-std.

Benchmark shows that there is still improvment room for yatp in serveral
cases, especially for future pool.

Only single level queue is benched as workload works for multilevel is
quite different from single level. It can be added in the future.