### PR TITLE
*: introduce coarse time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ parking_lot_core = "0.7"
 crossbeam-deque = "0.7"
 dashmap = "1.2.0"
 rand = "0.7"
+libc = "0.2"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,6 @@ pub mod pool;
 pub mod queue;
 pub mod task;
 
+mod time;
+
 pub use self::pool::{Builder, Remote, ThreadPool};

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -15,7 +15,7 @@ mod single_level;
 
 pub use self::extras::Extras;
 
-use std::time::Instant;
+use crate::time::CoarseInstant;
 
 /// A cell containing a task and needed extra information.
 pub trait TaskCell {
@@ -67,7 +67,8 @@ pub struct Pop<T> {
     pub task_cell: T,
 
     /// When the task was pushed to the queue.
-    pub schedule_time: Instant,
+    #[allow(dead_code)]
+    pub(crate) schedule_time: CoarseInstant,
 
     /// Whether the task comes from the current [`LocalQueue`] instead of being
     /// just stolen from the injector or other [`LocalQueue`]s.

--- a/src/queue/extras.rs
+++ b/src/queue/extras.rs
@@ -2,15 +2,15 @@
 
 use super::multilevel::ElapsedTime;
 
+use crate::time::CoarseInstant;
 use rand::prelude::*;
 use std::sync::Arc;
-use std::time::Instant;
 
 /// The extras for the task cells pushed into a queue.
 #[derive(Debug, Clone)]
 pub struct Extras {
     /// The instant when the task cell is pushed to the queue.
-    pub(crate) schedule_time: Option<Instant>,
+    pub(crate) schedule_time: Option<CoarseInstant>,
     /// The identifier of the task. Only used in the multilevel task queue.
     pub(crate) task_id: u64,
     /// The time spent on handling this task. Only used in the multilevel task

--- a/src/queue/single_level.rs
+++ b/src/queue/single_level.rs
@@ -7,11 +7,11 @@
 
 use super::{Pop, TaskCell};
 
+use crate::time::CoarseInstant;
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 use rand::prelude::*;
 use std::iter;
 use std::sync::Arc;
-use std::time::Instant;
 
 /// The injector of a single level work stealing task queue.
 pub struct TaskInjector<T>(Arc<Injector<T>>);
@@ -26,7 +26,7 @@ fn set_schedule_time<T>(task_cell: &mut T)
 where
     T: TaskCell,
 {
-    task_cell.mut_extras().schedule_time = Some(Instant::now());
+    task_cell.mut_extras().schedule_time = Some(CoarseInstant::now());
 }
 
 impl<T> TaskInjector<T>

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,84 @@
+// Copyright 2020 TiKV Project Authors. Licensed under Apache-2.0.
+
+use std::time::Duration;
+
+const NANOSECONDS_PER_SECOND: u32 = 1_000_000_000;
+
+#[derive(Copy, Clone, Debug)]
+pub struct CoarseInstant {
+    sec: u64,
+    nsec: u32,
+}
+
+impl CoarseInstant {
+    #[cfg(not(target_os = "linux"))]
+    pub fn now() -> CoarseInstant {
+        let n = std::time::SystemTime::now();
+        let dur = n.duration_since(std::time::SystemTime::UNIX_EPOCH);
+
+        CoarseInstant {
+            sec: dur.as_secs() as u64,
+            nsec: dur.subsec_nanos(),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn now() -> CoarseInstant {
+        let mut t = std::mem::MaybeUninit::uninit();
+        let errno = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC_COARSE, t.as_mut_ptr()) };
+        if errno == 0 {
+            let t = unsafe { t.assume_init() };
+            CoarseInstant {
+                sec: t.tv_sec as u64,
+                nsec: t.tv_nsec as u32,
+            }
+        } else {
+            panic!("unable to get time, error code: {}", errno);
+        }
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        let n = CoarseInstant::now();
+        n.duration_since(*self)
+    }
+
+    pub fn duration_since(&self, i: CoarseInstant) -> Duration {
+        if self.sec > i.sec {
+            if self.nsec >= i.nsec {
+                Duration::new(self.sec - i.sec, self.nsec - i.nsec)
+            } else {
+                Duration::new(
+                    self.sec - i.sec - 1,
+                    NANOSECONDS_PER_SECOND - (i.nsec - self.nsec),
+                )
+            }
+        } else if self.sec == i.sec && self.nsec >= i.nsec {
+            Duration::new(0, self.nsec - i.nsec)
+        } else {
+            Duration::new(0, 0)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn test_coarse_instant_on_smp() {
+        let zero = Duration::from_millis(0);
+        let timer = CoarseInstant::now();
+        for i in 0..1_000_000 {
+            let now = CoarseInstant::now();
+            if i % 100 == 0 {
+                thread::yield_now();
+            }
+            assert!(now.elapsed() >= zero);
+        }
+        std::thread::sleep(Duration::from_millis(10));
+        assert!(timer.elapsed() > zero);
+        assert!(CoarseInstant::now().duration_since(timer) > zero);
+    }
+}


### PR DESCRIPTION
Scheduling algorithm doesn't require accurate time measurement, so use
coarse time to reduce overhead. Benchmark shows that there are about 10%
improvement in all cases.