### PR TITLE
spawn through local queue if possible

### DIFF
--- a/benches/chained_spawn.rs
+++ b/benches/chained_spawn.rs
@@ -37,12 +37,12 @@ mod yatp_future {
     use criterion::*;
     use std::sync::mpsc;
     use yatp::task::future::TaskCell;
-    use yatp::Remote;
+    use yatp::Handle;
 
     pub fn chained_spawn(b: &mut Bencher<'_>, iter_count: usize) {
         let pool = yatp::Builder::new("chained_spawn").build_future_pool();
 
-        fn iter(remote: Remote<TaskCell>, done_tx: mpsc::SyncSender<()>, n: usize) {
+        fn iter(remote: Handle<TaskCell>, done_tx: mpsc::SyncSender<()>, n: usize) {
             if n == 0 {
                 done_tx.send(()).unwrap();
             } else {

--- a/benches/ping_pong.rs
+++ b/benches/ping_pong.rs
@@ -65,20 +65,20 @@ mod yatp_future {
             let rem = rem.clone();
             rem.store(ping_count, Ordering::Relaxed);
 
-            let remote = pool.remote().clone();
+            let handle = pool.handle().clone();
 
             pool.spawn(async move {
                 for _ in 0..ping_count {
                     let rem = rem.clone();
                     let done_tx = done_tx.clone();
 
-                    let remote2 = remote.clone();
+                    let handle2 = handle.clone();
 
-                    remote.spawn(async move {
+                    handle.spawn(async move {
                         let (tx1, rx1) = oneshot::channel();
                         let (tx2, rx2) = oneshot::channel();
 
-                        remote2.spawn(async move {
+                        handle2.spawn(async move {
                             rx1.await.unwrap();
                             tx2.send(()).unwrap();
                         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,4 +8,4 @@ pub mod pool;
 pub mod queue;
 pub mod task;
 
-pub use self::pool::{Builder, Remote, ThreadPool};
+pub use self::pool::{Builder, Handle, ThreadPool};

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -20,12 +20,12 @@ use std::sync::Mutex;
 use std::thread::JoinHandle;
 
 /// A generic thread pool.
-pub struct ThreadPool<T: TaskCell + Send> {
+pub struct ThreadPool<T: TaskCell + Send + 'static> {
     remote: Remote<T>,
     threads: Mutex<Vec<JoinHandle<()>>>,
 }
 
-impl<T: TaskCell + Send> ThreadPool<T> {
+impl<T: TaskCell + Send + 'static> ThreadPool<T> {
     /// Spawns the task into the thread pool.
     ///
     /// If the pool is shutdown, it becomes no-op.
@@ -50,7 +50,7 @@ impl<T: TaskCell + Send> ThreadPool<T> {
     }
 }
 
-impl<T: TaskCell + Send> Drop for ThreadPool<T> {
+impl<T: TaskCell + Send + 'static> Drop for ThreadPool<T> {
     /// Will shutdown the thread pool if it has not.
     fn drop(&mut self) {
         self.shutdown();

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -2,7 +2,7 @@
 
 use crate::pool::spawn::QueueCore;
 use crate::pool::worker::WorkerThread;
-use crate::pool::{CloneRunnerBuilder, Local, Remote, Runner, RunnerBuilder, ThreadPool};
+use crate::pool::{CloneRunnerBuilder, Handle, Local, Runner, RunnerBuilder, ThreadPool};
 use crate::queue::{self, LocalQueueBuilder, QueueType, TaskCell};
 use crate::task::{callback, future};
 use std::sync::{Arc, Mutex};
@@ -95,7 +95,7 @@ where
             );
         }
         ThreadPool {
-            remote: Remote::new(self.core.clone()),
+            handle: Handle::new(self.core.clone()),
             threads: Mutex::new(threads),
         }
     }
@@ -184,7 +184,7 @@ impl Builder {
     /// In some cases, especially building up a large application, a task
     /// scheduler is required before spawning new threads. You can use this
     /// to separate the construction and starting.
-    pub fn freeze<T>(&self) -> (Remote<T>, LazyBuilder<T>)
+    pub fn freeze<T>(&self) -> (Handle<T>, LazyBuilder<T>)
     where
         T: TaskCell + Send,
     {
@@ -200,7 +200,7 @@ impl Builder {
     /// In some cases, especially building up a large application, a task
     /// scheduler is required before spawning new threads. You can use this
     /// to separate the construction and starting.
-    pub fn freeze_with_queue<T>(&self, queue_type: QueueType) -> (Remote<T>, LazyBuilder<T>)
+    pub fn freeze_with_queue<T>(&self, queue_type: QueueType) -> (Handle<T>, LazyBuilder<T>)
     where
         T: TaskCell + Send,
     {
@@ -210,7 +210,7 @@ impl Builder {
         let core = Arc::new(QueueCore::new(injector, self.sched_config.clone()));
 
         (
-            Remote::new(core.clone()),
+            Handle::new(core.clone()),
             LazyBuilder {
                 builder: self.clone(),
                 core,

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -46,7 +46,7 @@ impl Default for SchedConfig {
 }
 
 /// A builder for lazy spawning.
-pub struct LazyBuilder<T: Send + 'static> {
+pub struct LazyBuilder<T> {
     builder: Builder,
     core: Arc<QueueCore<T>>,
     local_queue_builders: Vec<LocalQueueBuilder<T>>,
@@ -186,7 +186,7 @@ impl Builder {
     /// to separate the construction and starting.
     pub fn freeze<T>(&self) -> (Handle<T>, LazyBuilder<T>)
     where
-        T: TaskCell + Send,
+        T: TaskCell + Send + 'static,
     {
         self.freeze_with_queue(QueueType::SingleLevel)
     }
@@ -202,7 +202,7 @@ impl Builder {
     /// to separate the construction and starting.
     pub fn freeze_with_queue<T>(&self, queue_type: QueueType) -> (Handle<T>, LazyBuilder<T>)
     where
-        T: TaskCell + Send,
+        T: TaskCell + Send + 'static,
     {
         assert!(self.sched_config.min_thread_count <= self.sched_config.max_thread_count);
         let (injector, local_queue_builders) =

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -189,6 +189,12 @@ impl<T: TaskCell + Send + 'static> Handle<T> {
         })
     }
 
+    /// Spawns a task to the remote queue.
+    pub fn spawn_remote(&self, task: impl WithExtras<T>) {
+        let t = task.with_extras(|| self.core.default_extras());
+        self.core.push(0, t);
+    }
+
     pub(crate) fn stop(&self) {
         self.core.mark_shutdown(0);
     }

--- a/src/pool/tests.rs
+++ b/src/pool/tests.rs
@@ -78,21 +78,21 @@ fn test_basic() {
 }
 
 #[test]
-fn test_remote() {
-    let pool = Builder::new("test_remote")
+fn test_handle() {
+    let pool = Builder::new("test_handle")
         .max_thread_count(4)
         .build_callback_pool();
 
-    // Remote should work just like pool.
-    let remote = pool.remote();
+    // Handle should work just like pool.
+    let handle = pool.handle();
     let (tx, rx) = mpsc::channel();
     let t = tx.clone();
-    remote.spawn(move |_: &mut Handle<'_>| t.send(1).unwrap());
+    handle.spawn(move |_: &mut Handle<'_>| t.send(1).unwrap());
     assert_eq!(Ok(1), rx.recv_timeout(Duration::from_millis(500)));
 
     // Shutdown should stop processing tasks.
     pool.shutdown();
-    remote.spawn(move |_: &mut Handle<'_>| tx.send(2).unwrap());
+    handle.spawn(move |_: &mut Handle<'_>| tx.send(2).unwrap());
     let res = rx.recv_timeout(Duration::from_millis(500));
     assert_eq!(res, Err(mpsc::RecvTimeoutError::Timeout));
 }

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -2,10 +2,7 @@
 
 use crate::pool::{Local, Runner};
 use crate::queue::{Pop, TaskCell};
-use crossbeam_deque::Worker;
 use parking_lot_core::SpinWait;
-use std::cell::UnsafeCell;
-use std::rc::Rc;
 
 pub(crate) struct WorkerThread<T, R> {
     local: Local<T>,

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -15,6 +15,8 @@ mod single_level;
 
 pub use self::extras::Extras;
 
+use crossbeam_deque::Worker;
+use std::rc::Rc;
 use std::time::Instant;
 
 /// A cell containing a task and needed extra information.
@@ -44,7 +46,7 @@ enum InjectorInner<T> {
     Multilevel(multilevel::TaskInjector<T>),
 }
 
-impl<T: TaskCell + Send> TaskInjector<T> {
+impl<T: TaskCell + Send + 'static> TaskInjector<T> {
     /// Pushes a task to the queue.
     pub fn push(&self, task_cell: T) {
         match &self.0 {
@@ -57,6 +59,22 @@ impl<T: TaskCell + Send> TaskInjector<T> {
         match self.0 {
             InjectorInner::SingleLevel(_) => Extras::single_level(),
             InjectorInner::Multilevel(_) => Extras::multilevel_default(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn into_single_level(self) -> single_level::TaskInjector<T> {
+        match self.0 {
+            InjectorInner::SingleLevel(inj) => inj,
+            _ => unreachable!(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn into_multilevel(self) -> multilevel::TaskInjector<T> {
+        match self.0 {
+            InjectorInner::Multilevel(inj) => inj,
+            _ => unreachable!(),
         }
     }
 }
@@ -106,6 +124,38 @@ impl<T: TaskCell + Send> LocalQueue<T> {
             LocalQueueInner::Multilevel(_) => Extras::multilevel_default(),
         }
     }
+
+    pub fn local_injector(&self) -> LocalInjector<T> {
+        match &self.0 {
+            LocalQueueInner::SingleLevel(q) => q.local_injector(),
+            LocalQueueInner::Multilevel(q) => q.local_injector(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn into_single_level(self) -> single_level::LocalQueue<T> {
+        match self.0 {
+            LocalQueueInner::SingleLevel(q) => q,
+            _ => unreachable!(),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn into_multilevel(self) -> multilevel::LocalQueue<T> {
+        match self.0 {
+            LocalQueueInner::Multilevel(q) => q,
+            _ => unreachable!(),
+        }
+    }
+}
+
+// Note: Change it from struct to enum if there are other injector types.
+pub(crate) struct LocalInjector<T>(Rc<Worker<T>>);
+
+impl<T> LocalInjector<T> {
+    fn push(&self, task: T) {
+        self.0.push(task);
+    }
 }
 
 /// Supported available queues.
@@ -130,21 +180,14 @@ impl From<multilevel::Builder> for QueueType {
     }
 }
 
-pub(crate) fn build<T>(ty: QueueType, local_num: usize) -> (TaskInjector<T>, Vec<LocalQueue<T>>) {
+pub(crate) fn build<T: Send + 'static>(
+    ty: QueueType,
+    local_num: usize,
+) -> (TaskInjector<T>, Vec<LocalQueueBuilder<T>>) {
     match ty {
-        QueueType::SingleLevel => single_level(local_num),
+        QueueType::SingleLevel => single_level::create(local_num),
         QueueType::Multilevel(b) => b.build(local_num),
     }
 }
 
-/// Creates a task queue that allows given number consumers.
-fn single_level<T>(local_num: usize) -> (TaskInjector<T>, Vec<LocalQueue<T>>) {
-    let (injector, locals) = single_level::create(local_num);
-    (
-        TaskInjector(InjectorInner::SingleLevel(injector)),
-        locals
-            .into_iter()
-            .map(|i| LocalQueue(LocalQueueInner::SingleLevel(i)))
-            .collect(),
-    )
-}
+pub(crate) type LocalQueueBuilder<T> = Box<dyn FnOnce() -> LocalQueue<T> + Send>;

--- a/src/queue/multilevel.rs
+++ b/src/queue/multilevel.rs
@@ -790,10 +790,10 @@ mod tests {
         let builder = Builder::new(Config::default());
         let mut runner_builder = builder.runner_builder(MockRunnerBuilder);
         let manager = builder.manager.clone();
-        let (remote, mut locals) = build_spawn(builder, Default::default());
+        let (handle, mut locals) = build_spawn(builder, Default::default());
         let mut runner = runner_builder.build();
 
-        remote.spawn(MockTask::new(100, Extras::new_multilevel(1, None)));
+        handle.spawn(MockTask::new(100, Extras::new_multilevel(1, None)));
         if let Some(Pop { task_cell, .. }) = locals[0].pop() {
             assert!(runner.handle(&mut locals[0], task_cell));
         }

--- a/src/queue/single_level.rs
+++ b/src/queue/single_level.rs
@@ -5,7 +5,7 @@
 //! The instant when the task cell is pushed into the queue is recorded
 //! in the extras.
 
-use super::{LocalInjector, LocalQueueBuilder, Pop, TaskCell};
+use super::{LocalQueueBuilder, Pop, TaskCell};
 
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 use rand::prelude::*;
@@ -106,6 +106,15 @@ where
 
     pub(super) fn local_injector(&self) -> LocalInjector<T> {
         LocalInjector(self.local_queue.clone())
+    }
+}
+
+pub(crate) struct LocalInjector<T>(Rc<Worker<T>>);
+
+impl<T: TaskCell> LocalInjector<T> {
+    pub(super) fn push(&self, mut task: T) {
+        set_schedule_time(&mut task);
+        self.0.push(task);
     }
 }
 

--- a/src/queue/single_level.rs
+++ b/src/queue/single_level.rs
@@ -5,11 +5,12 @@
 //! The instant when the task cell is pushed into the queue is recorded
 //! in the extras.
 
-use super::{Pop, TaskCell};
+use super::{LocalInjector, LocalQueueBuilder, Pop, TaskCell};
 
 use crossbeam_deque::{Injector, Steal, Stealer, Worker};
 use rand::prelude::*;
 use std::iter;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -43,7 +44,7 @@ where
 
 /// The local queue of a single level work stealing task queue.
 pub struct LocalQueue<T> {
-    local_queue: Worker<T>,
+    local_queue: Rc<Worker<T>>,
     injector: Arc<Injector<T>>,
     stealers: Vec<Stealer<T>>,
 }
@@ -102,10 +103,16 @@ where
         }
         None
     }
+
+    pub(super) fn local_injector(&self) -> LocalInjector<T> {
+        LocalInjector(self.local_queue.clone())
+    }
 }
 
 /// Creates a single level work stealing task queue with `local_num` local queues.
-pub fn create<T>(local_num: usize) -> (TaskInjector<T>, Vec<LocalQueue<T>>) {
+pub(crate) fn create<T: Send + 'static>(
+    local_num: usize,
+) -> (super::TaskInjector<T>, Vec<LocalQueueBuilder<T>>) {
     let injector = Arc::new(Injector::new());
     let workers: Vec<_> = iter::repeat_with(Worker::new_lifo)
         .take(local_num)
@@ -114,24 +121,32 @@ pub fn create<T>(local_num: usize) -> (TaskInjector<T>, Vec<LocalQueue<T>>) {
     let local_queues = workers
         .into_iter()
         .enumerate()
-        .map(|(self_index, local_queue)| {
-            let mut stealers: Vec<_> = stealers
-                .iter()
-                .enumerate()
-                .filter(|(index, _)| *index != self_index)
-                .map(|(_, stealer)| stealer.clone())
-                .collect();
-            // Steal with a random start to avoid imbalance.
-            stealers.shuffle(&mut thread_rng());
-            LocalQueue {
-                local_queue,
-                injector: injector.clone(),
-                stealers,
-            }
-        })
+        .map(
+            |(self_index, local_queue)| -> Box<dyn FnOnce() -> super::LocalQueue<T> + Send> {
+                let mut stealers: Vec<_> = stealers
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| *index != self_index)
+                    .map(|(_, stealer)| stealer.clone())
+                    .collect();
+                // Steal with a random start to avoid imbalance.
+                stealers.shuffle(&mut thread_rng());
+                let injector = injector.clone();
+                Box::new(move || {
+                    super::LocalQueue(super::LocalQueueInner::SingleLevel(LocalQueue {
+                        local_queue: Rc::new(local_queue),
+                        injector,
+                        stealers,
+                    }))
+                })
+            },
+        )
         .collect();
 
-    (TaskInjector(injector), local_queues)
+    (
+        super::TaskInjector(super::InjectorInner::SingleLevel(TaskInjector(injector))),
+        local_queues,
+    )
 }
 
 #[cfg(test)]
@@ -168,7 +183,8 @@ mod tests {
     fn test_schedule_time_is_set() {
         const SLEEP_DUR: Duration = Duration::from_millis(5);
 
-        let (injector, mut locals) = super::create(1);
+        let (injector, locals) = super::create(1);
+        let mut locals: Vec<_> = locals.into_iter().map(|b| b()).collect();
         injector.push(MockCell::new(0));
         thread::sleep(SLEEP_DUR);
         let schedule_time = locals[0].pop().unwrap().schedule_time;
@@ -177,7 +193,8 @@ mod tests {
 
     #[test]
     fn test_pop_by_stealing_injector() {
-        let (injector, mut locals) = super::create(3);
+        let (injector, locals) = super::create(3);
+        let mut locals: Vec<_> = locals.into_iter().map(|b| b()).collect();
         for i in 0..100 {
             injector.push(MockCell::new(i));
         }
@@ -190,7 +207,12 @@ mod tests {
 
     #[test]
     fn test_pop_by_steal_others() {
-        let (injector, mut locals) = super::create(3);
+        let (injector, locals) = super::create(3);
+        let injector = injector.into_single_level();
+        let mut locals: Vec<_> = locals
+            .into_iter()
+            .map(|b| b().into_single_level())
+            .collect();
         for i in 0..50 {
             injector.push(MockCell::new(i));
         }
@@ -215,9 +237,10 @@ mod tests {
         let sum = Arc::new(AtomicI32::new(0));
         let handles: Vec<_> = locals
             .into_iter()
-            .map(|mut consumer| {
+            .map(|builder| {
                 let sum = sum.clone();
                 thread::spawn(move || {
+                    let mut consumer = builder();
                     while let Some(pop) = consumer.pop() {
                         sum.fetch_add(pop.task_cell.value, Ordering::SeqCst);
                     }


### PR DESCRIPTION
In this PR, if `spawn` happens in tne working threads, tasks are pushed into the local queue for locality. It also removes the local wake mechanism of futures. `Remote` is renamed to `Handle` for its new meaning.

Benchmark shows up to 100% improvement on chain_spawn.
But there is a regression on ping_pong  when `ping_count` is large. This is because it is much more expensive to increase the capacity of crossbeam `Worker` (allocating new buffer and copying all) than `Injector` (just adding a new block).