### PR TITLE
Reschedule only when there are awaiting tasks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,15 @@ crossbeam-deque = "0.7"
 dashmap = "1.2.0"
 rand = "0.7"
 lazy_static = "1"
+fail = "0.3"
 
 [dependencies.prometheus]
 # FIXME: Use crates-io version when rust-prometheus 0.8 is released
 git = "https://github.com/tikv/rust-prometheus.git"
 rev = "d919ccd35976b9b84b8d03c07138c1cc05a36087"
+
+[features]
+failpoints = ["fail/failpoints"]
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -6,6 +6,7 @@
 
 use crate::pool::SchedConfig;
 use crate::queue::{Extras, LocalQueue, Pop, TaskCell, TaskInjector, WithExtras};
+use fail::fail_point;
 use parking_lot_core::{ParkResult, ParkToken, UnparkToken};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -265,6 +266,7 @@ impl<T: TaskCell + Send> Local<T> {
     ///
     /// If the pool is not busy, other tasks should not preempt the current running task.
     pub(crate) fn need_preempt(&mut self) -> bool {
+        fail_point!("need-preempt", |r| { r.unwrap().parse().unwrap() });
         if self.core.busy_hint() {
             self.local_queue.has_tasks_or_pull()
         } else {

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -253,6 +253,10 @@ impl<T: TaskCell + Send> Local<T> {
             ParkResult::TimedOut => unreachable!(),
         }
     }
+
+    pub(crate) fn has_tasks(&mut self) -> bool {
+        self.local_queue.has_tasks()
+    }
 }
 
 /// Building remotes and locals from the given queue and configuration.

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -107,10 +107,12 @@ impl<T: TaskCell + Send> LocalQueue<T> {
         }
     }
 
-    pub fn has_tasks(&mut self) -> bool {
+    /// If there are tasks in the local queue, returns true. Otherwise, pulls
+    /// tasks from the global queue and returns whether it succeeds.
+    pub fn has_tasks_or_pull(&mut self) -> bool {
         match &mut self.0 {
-            LocalQueueInner::SingleLevel(q) => q.has_tasks(),
-            LocalQueueInner::Multilevel(q) => q.has_tasks(),
+            LocalQueueInner::SingleLevel(q) => q.has_tasks_or_pull(),
+            LocalQueueInner::Multilevel(q) => q.has_tasks_or_pull(),
         }
     }
 }

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -106,6 +106,13 @@ impl<T: TaskCell + Send> LocalQueue<T> {
             LocalQueueInner::Multilevel(_) => Extras::multilevel_default(),
         }
     }
+
+    pub fn has_tasks(&mut self) -> bool {
+        match &mut self.0 {
+            LocalQueueInner::SingleLevel(q) => q.has_tasks(),
+            LocalQueueInner::Multilevel(q) => q.has_tasks(),
+        }
+    }
 }
 
 /// Supported available queues.

--- a/src/queue/multilevel.rs
+++ b/src/queue/multilevel.rs
@@ -164,7 +164,7 @@ where
         None
     }
 
-    pub fn has_tasks(&mut self) -> bool {
+    pub fn has_tasks_or_pull(&mut self) -> bool {
         if !self.local_queue.is_empty() {
             return true;
         }

--- a/src/queue/multilevel.rs
+++ b/src/queue/multilevel.rs
@@ -163,6 +163,29 @@ where
         }
         None
     }
+
+    pub fn has_tasks(&mut self) -> bool {
+        if !self.local_queue.is_empty() {
+            return true;
+        }
+
+        let mut rng = thread_rng();
+        let level0_chance = self.manager.level0_chance.get();
+        loop {
+            let expected_level = if rng.gen::<f64>() < level0_chance {
+                0
+            } else {
+                (1..LEVEL_NUM - 1)
+                    .find(|_| rng.gen_ratio(CHANCE_RATIO, CHANCE_RATIO + 1))
+                    .unwrap_or(LEVEL_NUM - 1)
+            };
+            match self.level_injectors[expected_level].steal_batch(&self.local_queue) {
+                Steal::Success(()) => return true,
+                Steal::Empty => return false,
+                Steal::Retry => {}
+            }
+        }
+    }
 }
 
 /// The runner builder for multilevel task queues.

--- a/src/queue/single_level.rs
+++ b/src/queue/single_level.rs
@@ -102,6 +102,19 @@ where
         }
         None
     }
+
+    pub fn has_tasks(&mut self) -> bool {
+        if !self.local_queue.is_empty() {
+            return true;
+        }
+        loop {
+            match self.injector.steal_batch(&self.local_queue) {
+                Steal::Success(()) => return true,
+                Steal::Empty => return false,
+                Steal::Retry => {}
+            }
+        }
+    }
 }
 
 /// Creates a single level work stealing task queue with `local_num` local queues.

--- a/src/queue/single_level.rs
+++ b/src/queue/single_level.rs
@@ -103,7 +103,7 @@ where
         None
     }
 
-    pub fn has_tasks(&mut self) -> bool {
+    pub fn has_tasks_or_pull(&mut self) -> bool {
         if !self.local_queue.is_empty() {
             return true;
         }

--- a/src/task/future.rs
+++ b/src/task/future.rs
@@ -269,7 +269,7 @@ impl crate::pool::Runner for Runner {
                     Err(NOTIFIED) => {
                         let need_reschedule = NEED_RESCHEDULE.with(|r| r.replace(false));
                         if (repoll_times >= self.repoll_limit || need_reschedule)
-                            && scope.0.has_tasks()
+                            && scope.0.need_preempt()
                         {
                             wake_task(Cow::Owned(task), need_reschedule);
                             return false;


### PR DESCRIPTION
When a future task requires to yield, it is expected that another task comes to running. However, if the pool is not busy or there isn't any other task to run, it is pure waste to put the task back to the global queue.

This PR tries to fix https://github.com/tikv/tikv/issues/6962. It is confirmed that with this PR the regression is solved.
However, the problem isn't actually resolved perfectly. If the pool is busy, the CPU cache of the yielded task will be flushed by other tasks. I don't have a good idea now. Maybe each working thread can have its own strategy of retrieving tasks.