### PR TITLE
remove the inaccurate busy hint check

### DIFF
--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -118,13 +118,6 @@ impl<T> QueueCore<T> {
             }
         }
     }
-
-    /// Returns whether all threads in the pool is working.
-    ///
-    /// It's not necessarily accurate.
-    pub fn busy_hint(&self) -> bool {
-        self.active_workers.load(Ordering::Relaxed) == self.config.max_thread_count
-    }
 }
 
 impl<T: TaskCell + Send> QueueCore<T> {
@@ -267,11 +260,7 @@ impl<T: TaskCell + Send> Local<T> {
     /// If the pool is not busy, other tasks should not preempt the current running task.
     pub(crate) fn need_preempt(&mut self) -> bool {
         fail_point!("need-preempt", |r| { r.unwrap().parse().unwrap() });
-        if self.core.busy_hint() {
-            self.local_queue.has_tasks_or_pull()
-        } else {
-            false
-        }
+        self.local_queue.has_tasks_or_pull()
     }
 }
 


### PR DESCRIPTION
In real testing, the busy hint check returns false in most times. It leads to rescheduling not working. This PR removes the busy check. I test manually on TiKV that it works now.