### PR TITLE
pool: detect joining deadlock

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -17,7 +17,7 @@ pub use self::spawn::{build_spawn, Local, Remote};
 use crate::queue::{TaskCell, WithExtras};
 use std::mem;
 use std::sync::Mutex;
-use std::thread::JoinHandle;
+use std::thread::{self, JoinHandle};
 
 /// A generic thread pool.
 pub struct ThreadPool<T: TaskCell + Send> {
@@ -39,8 +39,11 @@ impl<T: TaskCell + Send> ThreadPool<T> {
     pub fn shutdown(&self) {
         self.remote.stop();
         let mut threads = mem::replace(&mut *self.threads.lock().unwrap(), Vec::new());
+        let curr_id = thread::current().id();
         for j in threads.drain(..) {
-            j.join().unwrap();
+            if curr_id != j.thread().id() {
+                j.join().unwrap();
+            }
         }
     }
 

--- a/src/pool/tests.rs
+++ b/src/pool/tests.rs
@@ -96,3 +96,17 @@ fn test_remote() {
     let res = rx.recv_timeout(Duration::from_millis(500));
     assert_eq!(res, Err(mpsc::RecvTimeoutError::Timeout));
 }
+
+#[test]
+fn test_shutdown_in_pool() {
+    let pool = Builder::new("test_shutdown_in_pool")
+        .max_thread_count(4)
+        .build_callback_pool();
+    let remote = pool.remote().clone();
+    let (tx, rx) = mpsc::channel();
+    remote.spawn(move |_: &mut Handle<'_>| {
+        pool.shutdown();
+        tx.send(()).unwrap();
+    });
+    rx.recv_timeout(Duration::from_secs(1)).unwrap();
+}


### PR DESCRIPTION
If a thread is joining self, it will panic.