### PR TITLE
*: adjust benchmark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,3 +45,4 @@ harness = false
 
 [profile.bench]
 codegen-units = 1
+debug = true

--- a/benches/chained_spawn.rs
+++ b/benches/chained_spawn.rs
@@ -134,7 +134,7 @@ mod async_std {
 
 pub fn chained_spawn(b: &mut Criterion) {
     let mut group = b.benchmark_group("chained_spawn");
-    for i in &[100, 400, 700, 1000] {
+    for i in &[256, 512, 1024] {
         group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
             yatp_future::chained_spawn(b, *i)
         });

--- a/benches/chained_spawn.rs
+++ b/benches/chained_spawn.rs
@@ -39,9 +39,7 @@ mod yatp_future {
     use yatp::task::future::TaskCell;
     use yatp::Remote;
 
-    pub fn chained_spawn(b: &mut Bencher<'_>, iter_count: usize) {
-        let pool = yatp::Builder::new("chained_spawn").build_future_pool();
-
+    fn chained_spawn(b: &mut Bencher<'_>, pool: yatp::ThreadPool<TaskCell>, iter_count: usize) {
         fn iter(remote: Remote<TaskCell>, done_tx: mpsc::SyncSender<()>, n: usize) {
             if n == 0 {
                 done_tx.send(()).unwrap();
@@ -64,6 +62,16 @@ mod yatp_future {
 
             done_rx.recv().unwrap();
         });
+    }
+
+    pub fn chained_spawn_single_level(b: &mut Bencher<'_>, iter_count: usize) {
+        let pool = yatp::Builder::new("chained_spawn").build_future_pool();
+        chained_spawn(b, pool, iter_count)
+    }
+
+    pub fn chained_spawn_multilevel(b: &mut Bencher<'_>, iter_count: usize) {
+        let pool = yatp::Builder::new("chained_spawn").build_multilevel_future_pool();
+        chained_spawn(b, pool, iter_count)
     }
 }
 
@@ -136,11 +144,16 @@ pub fn chained_spawn(b: &mut Criterion) {
     let mut group = b.benchmark_group("chained_spawn");
     for i in &[256, 512, 1024] {
         group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
-            yatp_future::chained_spawn(b, *i)
+            yatp_future::chained_spawn_single_level(b, *i)
         });
         group.bench_with_input(BenchmarkId::new("yatp::callback", i), i, |b, i| {
             yatp_callback::chained_spawn(b, *i)
         });
+        group.bench_with_input(
+            BenchmarkId::new("yatp::future::multilevel", i),
+            i,
+            |b, i| yatp_future::chained_spawn_multilevel(b, *i),
+        );
         group.bench_with_input(BenchmarkId::new("tokio", i), i, |b, i| {
             tokio::chained_spawn(b, *i)
         });

--- a/benches/ping_pong.rs
+++ b/benches/ping_pong.rs
@@ -199,7 +199,7 @@ mod async_std {
 
 pub fn ping_pong(b: &mut Criterion) {
     let mut group = b.benchmark_group("ping_pong");
-    for i in &[100, 400, 700, 1000] {
+    for i in &[256, 512, 1024] {
         group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
             yatp_future::ping_pong(b, *i)
         });

--- a/benches/spawn_many.rs
+++ b/benches/spawn_many.rs
@@ -60,6 +60,37 @@ mod yatp_future {
     }
 }
 
+mod yatp_future_multilevel {
+    use criterion::*;
+    use std::sync::atomic::*;
+    use std::sync::*;
+
+    pub fn spawn_many(b: &mut Bencher<'_>, spawn_count: usize) {
+        let (tx, rx) = mpsc::sync_channel(1000);
+        let rem = Arc::new(AtomicUsize::new(0));
+
+        let pool = yatp::Builder::new("spawn_many").build_multilevel_future_pool();
+        let mut id = 0;
+        b.iter(|| {
+            rem.store(spawn_count, Ordering::Relaxed);
+
+            for _ in 0..spawn_count {
+                let tx = tx.clone();
+                let rem = rem.clone();
+                id += 1;
+
+                pool.spawn(async move {
+                    if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
+                        tx.send(()).unwrap();
+                    }
+                });
+            }
+
+            let _ = rx.recv().unwrap();
+        });
+    }
+}
+
 mod threadpool {
     use criterion::*;
     use std::sync::atomic::*;
@@ -153,12 +184,15 @@ mod async_std {
 
 pub fn spawn_many(b: &mut Criterion) {
     let mut group = b.benchmark_group("spawn_many");
-    for i in &[1000, 4000, 7000, 10000] {
+    for i in &[1024, 4096, 8192, 16384] {
         group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
             yatp_future::spawn_many(b, *i)
         });
         group.bench_with_input(BenchmarkId::new("yatp::callback", i), i, |b, i| {
             yatp_callback::spawn_many(b, *i)
+        });
+        group.bench_with_input(BenchmarkId::new("yatp::future::multilevel", i), i, |b, i| {
+            yatp_future_multilevel::spawn_many(b, *i)
         });
         group.bench_with_input(BenchmarkId::new("threadpool", i), i, |b, i| {
             threadpool::spawn_many(b, *i)

--- a/benches/spawn_many.rs
+++ b/benches/spawn_many.rs
@@ -35,11 +35,11 @@ mod yatp_future {
     use criterion::*;
     use std::sync::atomic::*;
     use std::sync::*;
+    use yatp::task::future::TaskCell;
 
-    pub fn spawn_many(b: &mut Bencher<'_>, spawn_count: usize) {
+    fn spawn_many(b: &mut Bencher<'_>, pool: yatp::ThreadPool<TaskCell>, spawn_count: usize) {
         let (tx, rx) = mpsc::sync_channel(1000);
         let rem = Arc::new(AtomicUsize::new(0));
-        let pool = yatp::Builder::new("spawn_many").build_future_pool();
 
         b.iter(|| {
             rem.store(spawn_count, Ordering::Relaxed);
@@ -58,36 +58,15 @@ mod yatp_future {
             let _ = rx.recv().unwrap();
         });
     }
-}
 
-mod yatp_future_multilevel {
-    use criterion::*;
-    use std::sync::atomic::*;
-    use std::sync::*;
+    pub fn spawn_many_single_level(b: &mut Bencher<'_>, spawn_count: usize) {
+        let pool = yatp::Builder::new("spawn_many").build_future_pool();
+        spawn_many(b, pool, spawn_count)
+    }
 
-    pub fn spawn_many(b: &mut Bencher<'_>, spawn_count: usize) {
-        let (tx, rx) = mpsc::sync_channel(1000);
-        let rem = Arc::new(AtomicUsize::new(0));
-
+    pub fn spawn_many_multilevel(b: &mut Bencher<'_>, spawn_count: usize) {
         let pool = yatp::Builder::new("spawn_many").build_multilevel_future_pool();
-        let mut id = 0;
-        b.iter(|| {
-            rem.store(spawn_count, Ordering::Relaxed);
-
-            for _ in 0..spawn_count {
-                let tx = tx.clone();
-                let rem = rem.clone();
-                id += 1;
-
-                pool.spawn(async move {
-                    if 1 == rem.fetch_sub(1, Ordering::Relaxed) {
-                        tx.send(()).unwrap();
-                    }
-                });
-            }
-
-            let _ = rx.recv().unwrap();
-        });
+        spawn_many(b, pool, spawn_count)
     }
 }
 
@@ -186,14 +165,16 @@ pub fn spawn_many(b: &mut Criterion) {
     let mut group = b.benchmark_group("spawn_many");
     for i in &[1024, 4096, 8192, 16384] {
         group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
-            yatp_future::spawn_many(b, *i)
+            yatp_future::spawn_many_single_level(b, *i)
         });
         group.bench_with_input(BenchmarkId::new("yatp::callback", i), i, |b, i| {
             yatp_callback::spawn_many(b, *i)
         });
-        group.bench_with_input(BenchmarkId::new("yatp::future::multilevel", i), i, |b, i| {
-            yatp_future_multilevel::spawn_many(b, *i)
-        });
+        group.bench_with_input(
+            BenchmarkId::new("yatp::future::multilevel", i),
+            i,
+            |b, i| yatp_future::spawn_many_multilevel(b, *i),
+        );
         group.bench_with_input(BenchmarkId::new("threadpool", i), i, |b, i| {
             threadpool::spawn_many(b, *i)
         });

--- a/benches/yield_many.rs
+++ b/benches/yield_many.rs
@@ -146,7 +146,7 @@ mod async_std {
 
 pub fn yield_many(b: &mut Criterion) {
     let mut group = b.benchmark_group("yield_many");
-    for i in &[100, 400, 700, 1000] {
+    for i in &[256, 512, 1024] {
         group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
             yatp_future::yield_many(b, *i)
         });

--- a/benches/yield_many.rs
+++ b/benches/yield_many.rs
@@ -62,11 +62,11 @@ mod yatp_callback {
 mod yatp_future {
     use criterion::*;
     use std::sync::mpsc;
+    use yatp::task::future::TaskCell;
 
-    pub fn yield_many(b: &mut Bencher<'_>, yield_count: usize) {
+    fn yield_many(b: &mut Bencher<'_>, pool: yatp::ThreadPool<TaskCell>, yield_count: usize) {
         let tasks = super::TASKS_PER_CPU * num_cpus::get();
         let (tx, rx) = mpsc::sync_channel(tasks);
-        let pool = yatp::Builder::new("yield_many").build_future_pool();
 
         b.iter(move || {
             for _ in 0..tasks {
@@ -83,6 +83,16 @@ mod yatp_future {
                 let _ = rx.recv().unwrap();
             }
         });
+    }
+
+    pub fn yield_many_single_level(b: &mut Bencher<'_>, yield_count: usize) {
+        let pool = yatp::Builder::new("yield_many").build_future_pool();
+        yield_many(b, pool, yield_count)
+    }
+
+    pub fn yield_many_multilevel(b: &mut Bencher<'_>, yield_count: usize) {
+        let pool = yatp::Builder::new("yield_many").build_multilevel_future_pool();
+        yield_many(b, pool, yield_count)
     }
 }
 
@@ -148,11 +158,16 @@ pub fn yield_many(b: &mut Criterion) {
     let mut group = b.benchmark_group("yield_many");
     for i in &[256, 512, 1024] {
         group.bench_with_input(BenchmarkId::new("yatp::future", i), i, |b, i| {
-            yatp_future::yield_many(b, *i)
+            yatp_future::yield_many_single_level(b, *i)
         });
         group.bench_with_input(BenchmarkId::new("yatp::callback", i), i, |b, i| {
             yatp_callback::yield_many(b, *i)
         });
+        group.bench_with_input(
+            BenchmarkId::new("yatp::future::multilevel", i),
+            i,
+            |b, i| yatp_future::yield_many_multilevel(b, *i),
+        );
         group.bench_with_input(BenchmarkId::new("tokio", i), i, |b, i| {
             tokio::yield_many(b, *i)
         });

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -3,7 +3,7 @@
 use crate::pool::spawn::QueueCore;
 use crate::pool::worker::WorkerThread;
 use crate::pool::{CloneRunnerBuilder, Local, Remote, Runner, RunnerBuilder, ThreadPool};
-use crate::queue::{self, LocalQueue, QueueType, TaskCell, multilevel};
+use crate::queue::{self, multilevel, LocalQueue, QueueType, TaskCell};
 use crate::task::{callback, future};
 use std::sync::{Arc, Mutex};
 use std::thread;

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -3,7 +3,7 @@
 use crate::pool::spawn::QueueCore;
 use crate::pool::worker::WorkerThread;
 use crate::pool::{CloneRunnerBuilder, Local, Remote, Runner, RunnerBuilder, ThreadPool};
-use crate::queue::{self, LocalQueue, QueueType, TaskCell};
+use crate::queue::{self, LocalQueue, QueueType, TaskCell, multilevel};
 use crate::task::{callback, future};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -231,6 +231,16 @@ impl Builder {
     pub fn build_future_pool(&self) -> ThreadPool<future::TaskCell> {
         let fb = CloneRunnerBuilder(future::Runner::default());
         self.build_with_queue_and_runner(QueueType::SingleLevel, fb)
+    }
+
+    /// Spawns a multilevel future pool.
+    ///
+    /// It setups the pool with multi level queue.
+    pub fn build_multilevel_future_pool(&self) -> ThreadPool<future::TaskCell> {
+        let fb = CloneRunnerBuilder(future::Runner::default());
+        let queue_builder = multilevel::Builder::new(multilevel::Config::default());
+        let runner_builder = queue_builder.runner_builder(fb);
+        self.build_with_queue_and_runner(QueueType::Multilevel(queue_builder), runner_builder)
     }
 
     /// Spawns the thread pool immediately.


### PR DESCRIPTION
100 is hard to be distinguished from 1000 when filtering benchmark case,
so this PR changes the dataset to be 2 based.

A benchmark to multilevel queue is also added.
