### PR TITLE
adjust active thread count adaptively

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -27,6 +27,17 @@ lazy_static! {
     )
     .unwrap();
 
+    /// The count of active workers.
+    pub static ref ACTIVE_WORKERS_COUNT: HistogramVec = HistogramVec::new(
+        histogram_opts!(
+            "yatp_active_workers_count",
+            "the count of backup workers",
+            vec![1.0, 2.0, 4.0, 6.0, 8.0, 12.0, 16.0, 24.0, 32.0, 48.0, 64.0, 96.0, 128.0]
+        ),
+        &["name"]
+    )
+    .unwrap();
+
     static ref NAMESPACE: Mutex<Option<String>> = Mutex::new(None);
 }
 

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -1,5 +1,6 @@
 // Copyright 2019 TiKV Project Authors. Licensed under Apache-2.0.
 
+use crate::metrics::*;
 use crate::pool::spawn::QueueCore;
 use crate::pool::worker::WorkerThread;
 use crate::pool::{CloneRunnerBuilder, Local, Remote, Runner, RunnerBuilder, ThreadPool};
@@ -76,6 +77,9 @@ where
         F::Runner: Runner<TaskCell = T> + Send + 'static,
     {
         let mut threads = Vec::with_capacity(self.builder.sched_config.max_thread_count);
+        let active_count_histogram = ACTIVE_WORKERS_COUNT
+            .get_metric_with_label_values(&[&self.builder.name_prefix])
+            .unwrap();
         for (i, local_queue) in self.local_queues.into_iter().enumerate() {
             let runner = factory.build();
             let name = format!("{}-{}", self.builder.name_prefix, i);
@@ -83,7 +87,12 @@ where
             if let Some(size) = self.builder.stack_size {
                 builder = builder.stack_size(size)
             }
-            let local = Local::new(i + 1, local_queue, self.core.clone());
+            let local = Local::new(
+                i + 1,
+                local_queue,
+                self.core.clone(),
+                active_count_histogram.clone(),
+            );
             let thd = WorkerThread::new(local, runner);
             threads.push(
                 builder

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -432,6 +432,7 @@ impl<T: TaskCell + Send> Local<T> {
         match res {
             ParkResult::Unparked(_) | ParkResult::Invalid => {
                 self.core.mark_woken(backup);
+                self.core.ensure_workers(id);
                 task
             }
             ParkResult::TimedOut => unreachable!(),

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -28,8 +28,6 @@ trait WorkersInfo {
 
     fn backup_count(self) -> usize;
 
-    fn set_shutdown(self) -> Self;
-
     // Change an active worker from not running to running.
     fn active_to_running(self) -> Self;
 
@@ -72,17 +70,13 @@ impl WorkersInfo for u64 {
         ((self >> BACKUP_COUNT_SHIFT) & COUNT_MASK) as usize
     }
 
-    fn set_shutdown(self) -> Self {
-        self | SHUTDOWN_BIT
-    }
-
     fn active_to_running(self) -> Self {
-        debug_assert!(self.running_count() < self.active_count());
+        debug_assert!(self.is_shutdown() || self.running_count() < self.active_count());
         self + (1 << RUNNING_COUNT_SHIFT)
     }
 
     fn running_to_active(self) -> Self {
-        debug_assert!(self.running_count() > 0);
+        debug_assert!(self.is_shutdown() || self.running_count() > 0);
         self - (1 << RUNNING_COUNT_SHIFT)
     }
 

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -24,18 +24,18 @@ where
 {
     #[inline]
     fn pop(&mut self) -> Option<Pop<T>> {
-        self.local.core().ensure_workers(self.local.id);
         let idling = self.local.core().mark_idling();
         let mut counter = 0;
         while idling {
             if let Some(t) = self.local.pop() {
                 self.local.core().unmark_idling();
+                self.local.core().ensure_workers(self.local.id);
                 return Some(t);
             }
             counter += 1;
             if counter < 3 {
                 thread::yield_now();
-            } else if counter < 100 {
+            } else if counter < 10 {
                 thread::sleep(Duration::from_micros(10));
             } else {
                 self.local.core().unmark_idling();

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -24,6 +24,9 @@ where
     fn pop(&mut self) -> Option<Pop<T>> {
         for counter in 0..10 {
             if let Some(t) = self.local.pop() {
+                // if t.schedule_time.elapsed() > Duration::from_millis(1) {
+                //     self.local.core().unpark_one(true, self.local.id);
+                // }
                 self.local.core().ensure_workers(self.local.id);
                 return Some(t);
             }
@@ -61,7 +64,7 @@ mod tests {
     use crate::queue::QueueType;
     use crate::task::callback;
     use std::sync::*;
-    use std::time::*;
+    use std::time::Duration;
 
     #[derive(Default, PartialEq, Debug)]
     struct Metrics {

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -124,7 +124,9 @@ mod tests {
         };
         let metrics = r.metrics.clone();
         let mut expected_metrics = Metrics::default();
-        let (injector, mut locals) = build_spawn(QueueType::SingleLevel, Default::default());
+        let mut config = crate::pool::SchedConfig::default();
+        config.max_thread_count = 1;
+        let (injector, mut locals) = build_spawn(QueueType::SingleLevel, config);
         let th = WorkerThread::new(locals.remove(0), r);
         let handle = std::thread::spawn(move || {
             th.run();

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -24,6 +24,7 @@ where
 {
     #[inline]
     fn pop(&mut self) -> Option<Pop<T>> {
+        self.local.core().ensure_workers(self.local.id);
         let idling = self.local.core().mark_idling();
         let mut counter = 0;
         while idling {

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -2,9 +2,7 @@
 
 use crate::pool::{Local, Runner};
 use crate::queue::{Pop, TaskCell};
-use parking_lot_core::SpinWait;
 use std::thread;
-use std::time::Duration;
 
 pub(crate) struct WorkerThread<T, R> {
     local: Local<T>,
@@ -24,10 +22,8 @@ where
 {
     #[inline]
     fn pop(&mut self) -> Option<Pop<T>> {
-        // let idling = self.local.core().mark_idling();
         for counter in 0..10 {
             if let Some(t) = self.local.pop() {
-                // self.local.core().unmark_idling();
                 self.local.core().ensure_workers(self.local.id);
                 return Some(t);
             }


### PR DESCRIPTION
Edit: The self-adaptive strategy still needs some tuning. It's not so responsive in front of changing workloads

This PR adds another parking lot called `backup`. The threads parking in `backup` are much less often waked up. The workers except the backup ones are called `active` workers. The workers which are not parked are called `running` workers.

The working threads checks and records whether enough threads are utilized. If not enough threads are utilized continuously, a thread will be parked to the backup queue. 

In contrast, if all threads are keeping utilized, it means we don't have enough working threads and we should unpark one from `backup`.

~~In this PR, the `spawn` method unparks threads only if the current running threads are less than `min_thread_count`. This reduces the latency in spawn side because `unpark_one` is a bit costy.
In most cases, `ensure_workers` is called by working threads when they pop a task from the queue.~~