### PR TITLE
Make futures only hold weak ptr of the core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ criterion = "0.3"
 tokio = { version = "0.2.0", features = ["sync", "rt-threaded"] }
 async-std = "1.0"
 threadpool = "1.0"
+futures-timer = "3"
 
 [[bench]]
 name = "spawn_many"

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -12,6 +12,7 @@ mod worker;
 
 pub use self::builder::{Builder, SchedConfig};
 pub use self::runner::{CloneRunnerBuilder, Runner, RunnerBuilder};
+pub(crate) use self::spawn::WeakRemote;
 pub use self::spawn::{build_spawn, Local, Remote};
 
 use crate::queue::{TaskCell, WithExtras};

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -94,7 +94,7 @@ where
             );
         }
         ThreadPool {
-            remote: Remote::new(&self.core),
+            remote: Remote::new(self.core),
             threads: Mutex::new(threads),
         }
     }
@@ -208,7 +208,7 @@ impl Builder {
         let core = Arc::new(QueueCore::new(injector, self.sched_config.clone()));
 
         (
-            Remote::new(&core),
+            Remote::new(core.clone()),
             LazyBuilder {
                 builder: self.clone(),
                 core,

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -94,7 +94,7 @@ where
             );
         }
         ThreadPool {
-            remote: Remote::new(self.core),
+            remote: Remote::new(&self.core),
             threads: Mutex::new(threads),
         }
     }
@@ -208,7 +208,7 @@ impl Builder {
         let core = Arc::new(QueueCore::new(injector, self.sched_config.clone()));
 
         (
-            Remote::new(core.clone()),
+            Remote::new(&core),
             LazyBuilder {
                 builder: self.clone(),
                 core,

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -155,13 +155,6 @@ impl<T: TaskCell + Send> Remote<T> {
         self.core.push(0, t);
     }
 
-    /// Creates a `WeakRemote` from the `Remote`.
-    pub(crate) fn downgrade(&self) -> WeakRemote<T> {
-        WeakRemote {
-            core: Arc::downgrade(&self.core),
-        }
-    }
-
     pub(crate) fn stop(&self) {
         self.core.mark_shutdown(0);
     }

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -48,6 +48,9 @@ where
             self.runner.handle(&mut self.local, task.task_cell);
         }
         self.runner.end(&mut self.local);
+
+        // Drain all futures in the queue
+        while let Some(_) = self.local.pop() {}
     }
 }
 

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -50,7 +50,7 @@ where
         self.runner.end(&mut self.local);
 
         // Drain all futures in the queue
-        while let Some(_) = self.local.pop() {}
+        while self.local.pop().is_some() {}
     }
 }
 

--- a/src/task/future.rs
+++ b/src/task/future.rs
@@ -163,7 +163,7 @@ unsafe fn clone_task(task: *const Task) -> TaskCell {
     let extras = { &mut *task_cell.0.extras.get() };
     if extras.remote.is_none() {
         LOCAL.with(|l| {
-            extras.remote = Some((&*l.get()).remote().downgrade());
+            extras.remote = Some((&*l.get()).weak_remote());
         })
     }
     mem::forget(task_cell.0.clone());


### PR DESCRIPTION
Closes #46 

This PR makes `Remote` not hold a strong reference to the core and always check if the core is still alive before any operation.

This adds extra cost that upgrades a weak ptr to a strong Arc.

```
chained_spawn/yatp::future/1024                                                                            
                        time:   [906.10 us 913.73 us 919.75 us]
                        change: [-2.0794% -0.7563% +0.6007%] (p = 0.29 > 0.05)
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) low severe
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
ping_pong/yatp::future/1024                                                                             
                        time:   [1.0532 ms 1.0718 ms 1.0913 ms]
                        change: [-4.8954% -2.4524% +0.2339%] (p = 0.07 > 0.05)
                        No change in performance detected.

     Running target/release/deps/spawn_many-c9d51dfaec34d6eb
spawn_many/yatp::future/1024                                                                             
                        time:   [3.6443 ms 3.7237 ms 3.7983 ms]
                        change: [-2.0927% +0.9957% +4.0339%] (p = 0.52 > 0.05)
                        No change in performance detected.

     Running target/release/deps/yield_many-939c8e996b0eade2
yield_many/yatp::future/1024                                                                             
                        time:   [3.0346 ms 3.0890 ms 3.1437 ms]
                        change: [-1.2660% +1.2049% +3.7731%] (p = 0.34 > 0.05)
                        No change in performance detected.
```