### PR TITLE
Update tokio to 0.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ failpoints = ["fail/failpoints"]
 
 [dev-dependencies]
 criterion = "0.3"
-tokio = { version = "0.2.0", features = ["sync", "rt-threaded"] }
+tokio = { version = "0.3", features = ["sync", "rt-multi-thread"] }
 async-std = "1.0"
 threadpool = "1.0"
 futures-timer = "3"

--- a/benches/ping_pong.rs
+++ b/benches/ping_pong.rs
@@ -119,7 +119,6 @@ mod tokio {
             .worker_threads(num_cpus::get())
             .build()
             .unwrap();
-        let pool = Arc::new(pool);
 
         let (done_tx, done_rx) = mpsc::sync_channel(1000);
         let rem = Arc::new(AtomicUsize::new(0));
@@ -129,7 +128,7 @@ mod tokio {
             let rem = rem.clone();
             rem.store(ping_count, Ordering::Relaxed);
 
-            let handle = pool.clone();
+            let handle = pool.handle().clone();
 
             pool.spawn(async move {
                 for _ in 0..ping_count {

--- a/benches/ping_pong.rs
+++ b/benches/ping_pong.rs
@@ -115,11 +115,11 @@ mod tokio {
     use tokio::sync::oneshot;
 
     pub fn ping_pong(b: &mut Bencher<'_>, ping_count: usize) {
-        let pool = Builder::new()
-            .threaded_scheduler()
-            .core_threads(num_cpus::get())
+        let pool = Builder::new_multi_thread()
+            .worker_threads(num_cpus::get())
             .build()
             .unwrap();
+        let pool = Arc::new(pool);
 
         let (done_tx, done_rx) = mpsc::sync_channel(1000);
         let rem = Arc::new(AtomicUsize::new(0));
@@ -129,7 +129,7 @@ mod tokio {
             let rem = rem.clone();
             rem.store(ping_count, Ordering::Relaxed);
 
-            let handle = pool.handle().clone();
+            let handle = pool.clone();
 
             pool.spawn(async move {
                 for _ in 0..ping_count {

--- a/benches/spawn_many.rs
+++ b/benches/spawn_many.rs
@@ -108,9 +108,8 @@ mod tokio {
     pub fn spawn_many(b: &mut Bencher<'_>, spawn_count: usize) {
         let (tx, rx) = mpsc::sync_channel(1000);
         let rem = Arc::new(AtomicUsize::new(0));
-        let pool = Builder::new()
-            .threaded_scheduler()
-            .core_threads(num_cpus::get())
+        let pool = Builder::new_multi_thread()
+            .worker_threads(num_cpus::get())
             .build()
             .unwrap();
 

--- a/benches/yield_many.rs
+++ b/benches/yield_many.rs
@@ -104,9 +104,8 @@ mod tokio {
     pub fn yield_many(b: &mut Bencher<'_>, yield_count: usize) {
         let tasks = super::TASKS_PER_CPU * num_cpus::get();
         let (tx, rx) = mpsc::sync_channel(tasks);
-        let pool = Builder::new()
-            .threaded_scheduler()
-            .core_threads(num_cpus::get())
+        let pool = Builder::new_multi_thread()
+            .worker_threads(num_cpus::get())
             .build()
             .unwrap();
 


### PR DESCRIPTION
Tokio 0.3 is out for some days, might be interesting to see the benchmark with it.

But my change here seems still have some issues such for that ping_pong bench:
```
Benchmarking ping_pong/tokio/512: Collecting 100 samples in estimated 6.5420 s (20k iterations)thread 'tokio-runtime-worker' panicked at 'Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.', /Users/fuyangl/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-0.3.3/src/runtime/blocking/shutdown.rs:51:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'tokio-runtime-worker' has overflowed its stack
fatal runtime error: stack overflow
error: process didn't exit successfully: `/Users/fuyangl/Workspace/yatp/target/release/deps/ping_pong-4c2752ff3e0de76a ping_pong --bench` (signal: 6, SIGABRT: process abort signal)
```

Need to solve this first I suppose. 