### PR TITLE
fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,5 +16,6 @@ _It is still a work in progress._
 * **Generic**: Yatp is easily adapted to various tasks. Simple callbacks and
   [Future] are built-in supported.
 
-[MLFQ]: https://en.wikipedia.org/wiki/Multilevel_feedback_queue
-[Future]: https://doc.rust-lang.org/stable/std/future/trait.Future.html
+MLFQ: https://en.wikipedia.org/wiki/Multilevel_feedback_queue
+
+Future: https://doc.rust-lang.org/stable/std/future/trait.Future.html


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

The format is wrong and can not be rendered by markdown engine. This PR fixes it.
