### PR TITLE
Reduce one allocation in spawning a future

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -39,7 +39,7 @@ impl<T: TaskCell + Send> ThreadPool<T> {
     /// Closes the queue and wait for all threads to exit.
     pub fn shutdown(&self) {
         self.remote.stop();
-        let mut threads = mem::replace(&mut *self.threads.lock().unwrap(), Vec::new());
+        let mut threads = mem::take(&mut *self.threads.lock().unwrap());
         let curr_id = thread::current().id();
         for j in threads.drain(..) {
             if curr_id != j.thread().id() {

--- a/src/task/future.rs
+++ b/src/task/future.rs
@@ -9,8 +9,12 @@ use std::cell::{Cell, UnsafeCell};
 use std::future::Future;
 use std::mem::ManuallyDrop;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU8, Ordering::SeqCst};
-use std::sync::Arc;
+use std::ptr::NonNull;
+use std::sync::atomic::{
+    AtomicU8, AtomicUsize,
+    Ordering::{Acquire, Relaxed, Release, SeqCst},
+};
+use std::sync::{atomic, Arc};
 use std::task::{Context, Poll, RawWaker, RawWakerVTable, Waker};
 use std::{borrow::Cow, ptr};
 use std::{fmt, mem};
@@ -24,19 +28,71 @@ struct TaskExtras {
     remote: Option<WeakRemote<TaskCell>>,
 }
 
-/// A [`Future`] task.
-pub struct Task {
+#[repr(C)]
+struct RawTask<F> {
+    ref_count: AtomicUsize,
     status: AtomicU8,
     extras: UnsafeCell<TaskExtras>,
-    future: UnsafeCell<Pin<Box<dyn Future<Output = ()> + Send + 'static>>>,
+    poll_fn: fn(&TaskCell, &mut Context<'_>) -> Poll<()>,
+    data: UnsafeCell<F>,
 }
 
-/// A [`Future`] task cell.
-pub struct TaskCell(Arc<Task>);
+impl<F> RawTask<F>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    fn poll(task: &TaskCell, cx: &mut Context<'_>) -> Poll<()> {
+        let mut typed_ptr: NonNull<RawTask<F>> = task.0.cast();
+        unsafe { Pin::new_unchecked(typed_ptr.as_mut().data.get_mut()).poll(cx) }
+    }
+}
 
-// Safety: It is ensured that `future` and `extras` are always accessed by
-// only one thread at the same time.
-unsafe impl Sync for Task {}
+/// A reference counted `RawTask`.
+pub struct TaskCell(NonNull<RawTask<()>>);
+
+unsafe impl Send for TaskCell {}
+unsafe impl Sync for TaskCell {}
+
+impl TaskCell {
+    fn status(&self) -> &AtomicU8 {
+        unsafe { &self.0.as_ref().status }
+    }
+
+    fn extras(&self) -> &UnsafeCell<TaskExtras> {
+        unsafe { &self.0.as_ref().extras }
+    }
+
+    unsafe fn poll(&self, cx: &mut Context<'_>) -> Poll<()> {
+        (self.0.as_ref().poll_fn)(self, cx)
+    }
+
+    fn into_raw(self) -> *const () {
+        self.0.as_ptr() as _
+    }
+
+    unsafe fn from_raw(ptr: *const ()) -> Self {
+        TaskCell(NonNull::new_unchecked(ptr as _))
+    }
+}
+
+impl Clone for TaskCell {
+    fn clone(&self) -> Self {
+        unsafe { self.0.as_ref().ref_count.fetch_add(1, Relaxed) };
+        TaskCell(self.0)
+    }
+}
+
+impl Drop for TaskCell {
+    fn drop(&mut self) {
+        unsafe {
+            if self.0.as_ref().ref_count.fetch_sub(1, Release) != 1 {
+                return;
+            }
+        }
+        atomic::fence(Acquire);
+        unsafe { ptr::drop_in_place(self.0.as_ptr()) };
+    }
+}
 
 impl fmt::Debug for TaskCell {
     #[inline]
@@ -69,53 +125,55 @@ const COMPLETED: u8 = 4;
 impl TaskCell {
     /// Creates a [`Future`] task cell that is ready to be polled.
     pub fn new<F: Future<Output = ()> + Send + 'static>(future: F, extras: Extras) -> Self {
-        TaskCell(Arc::new(Task {
+        let inner = Box::new(RawTask {
+            ref_count: AtomicUsize::new(1),
             status: AtomicU8::new(NOTIFIED),
-            future: UnsafeCell::new(Box::pin(future)),
             extras: UnsafeCell::new(TaskExtras {
                 extras,
                 remote: None,
             }),
-        }))
+            poll_fn: RawTask::<F>::poll,
+            data: UnsafeCell::new(future),
+        });
+        unsafe { TaskCell(NonNull::new_unchecked(Box::into_raw(inner) as _)) }
     }
 }
 
 impl crate::queue::TaskCell for TaskCell {
     fn mut_extras(&mut self) -> &mut Extras {
-        unsafe { &mut (*self.0.extras.get()).extras }
+        unsafe { &mut (*self.0.as_ref().extras.get()).extras }
     }
 }
 
 #[inline]
-unsafe fn waker(task: *const Task) -> Waker {
+unsafe fn waker(task: TaskCell) -> Waker {
     Waker::from_raw(RawWaker::new(
-        task as *const (),
+        task.into_raw(),
         &RawWakerVTable::new(clone_raw, wake_raw, wake_ref_raw, drop_raw),
     ))
 }
 
 #[inline]
 unsafe fn clone_raw(this: *const ()) -> RawWaker {
-    let task_cell = clone_task(this as *const Task);
+    let task_cell = clone_task(this);
     RawWaker::new(
-        Arc::into_raw(task_cell.0) as *const (),
+        task_cell.into_raw(),
         &RawWakerVTable::new(clone_raw, wake_raw, wake_ref_raw, drop_raw),
     )
 }
 
 #[inline]
 unsafe fn drop_raw(this: *const ()) {
-    drop(task_cell(this as *const Task))
+    drop(TaskCell::from_raw(this))
 }
 
-unsafe fn wake_impl(task: Cow<'_, Arc<Task>>) {
-    let mut status = task.as_ref().status.load(SeqCst);
+unsafe fn wake_impl(task: Cow<'_, TaskCell>) {
+    let mut status = task.status().load(SeqCst);
     loop {
         match status {
             IDLE => {
                 match task
-                    .as_ref()
-                    .status
+                    .status()
                     .compare_exchange_weak(IDLE, NOTIFIED, SeqCst, SeqCst)
                 {
                     Ok(_) => {
@@ -127,8 +185,7 @@ unsafe fn wake_impl(task: Cow<'_, Arc<Task>>) {
             }
             POLLING => {
                 match task
-                    .as_ref()
-                    .status
+                    .status()
                     .compare_exchange_weak(POLLING, NOTIFIED, SeqCst, SeqCst)
                 {
                     Ok(_) => break,
@@ -142,31 +199,26 @@ unsafe fn wake_impl(task: Cow<'_, Arc<Task>>) {
 
 #[inline]
 unsafe fn wake_raw(this: *const ()) {
-    let task_cell = task_cell(this as *const Task);
-    wake_impl(Cow::Owned(task_cell.0));
+    let task_cell = TaskCell::from_raw(this);
+    wake_impl(Cow::Owned(task_cell));
 }
 
 #[inline]
 unsafe fn wake_ref_raw(this: *const ()) {
-    let task_cell = ManuallyDrop::new(task_cell(this as *const Task));
-    wake_impl(Cow::Borrowed(&task_cell.0));
+    let task_cell = ManuallyDrop::new(TaskCell::from_raw(this));
+    wake_impl(Cow::Borrowed(&task_cell));
 }
 
 #[inline]
-unsafe fn task_cell(task: *const Task) -> TaskCell {
-    TaskCell(Arc::from_raw(task))
-}
-
-#[inline]
-unsafe fn clone_task(task: *const Task) -> TaskCell {
-    let task_cell = task_cell(task);
-    let extras = { &mut *task_cell.0.extras.get() };
+unsafe fn clone_task(task: *const ()) -> TaskCell {
+    let task_cell = TaskCell::from_raw(task);
+    let extras = &mut *task_cell.extras().get();
     if extras.remote.is_none() {
         LOCAL.with(|l| {
             extras.remote = Some((&*l.get()).weak_remote());
         })
     }
-    mem::forget(task_cell.0.clone());
+    mem::forget(task_cell.clone());
     task_cell
 }
 
@@ -175,12 +227,12 @@ thread_local! {
     static LOCAL: Cell<*mut Local<TaskCell>> = Cell::new(std::ptr::null_mut());
 }
 
-unsafe fn wake_task(task: Cow<'_, Arc<Task>>, reschedule: bool) {
+unsafe fn wake_task(task: Cow<'_, TaskCell>, reschedule: bool) {
     LOCAL.with(|ptr| {
         // `wake_task` is only called when the status of the task is IDLE. Before the
         // status is set to IDLE, the runtime will set `remote` in `TaskExtras`. So we
         // can make sure `remote` is not None.
-        let task_remote = (*task.as_ref().extras.get())
+        let task_remote = (*task.extras().get())
             .remote
             .as_ref()
             .expect("core should exist!!!");
@@ -191,14 +243,14 @@ unsafe fn wake_task(task: Cow<'_, Arc<Task>>, reschedule: bool) {
             // It needs to clone to make it safe as it's unclear whether `self`
             // is still used inside method `spawn` after `TaskCell` is dropped.
             if let Some(remote) = task_remote.upgrade() {
-                remote.spawn(TaskCell(task.clone().into_owned()));
+                remote.spawn(task.clone().into_owned());
             }
         } else if reschedule {
             // It's requested explicitly to schedule to global queue.
-            (*ptr.get()).spawn_remote(TaskCell(task.into_owned()));
+            (*ptr.get()).spawn_remote(task.into_owned());
         } else {
             // Otherwise spawns to local queue for best locality.
-            (*ptr.get()).spawn(TaskCell(task.into_owned()));
+            (*ptr.get()).spawn(task.into_owned());
         }
     })
 }
@@ -251,18 +303,18 @@ impl crate::pool::Runner for Runner {
 
     fn handle(&mut self, local: &mut Local<TaskCell>, task_cell: TaskCell) -> bool {
         let scope = Scope::new(local);
-        let task = task_cell.0;
+        let task = TaskCell(task_cell.0);
         unsafe {
-            let waker = ManuallyDrop::new(waker(&*task));
+            let waker = ManuallyDrop::new(waker(task_cell));
             let mut cx = Context::from_waker(&waker);
             let mut repoll_times = 0;
             loop {
-                task.status.store(POLLING, SeqCst);
-                if (&mut *task.future.get()).as_mut().poll(&mut cx).is_ready() {
-                    task.status.store(COMPLETED, SeqCst);
+                task.status().store(POLLING, SeqCst);
+                if task.poll(&mut cx).is_ready() {
+                    task.status().store(COMPLETED, SeqCst);
                     return true;
                 }
-                let extras = { &mut *task.extras.get() };
+                let extras = { &mut *task.extras().get() };
                 if extras.remote.is_none() {
                     // It's possible to avoid assigning remote in some cases, but it requires
                     // at least one atomic load to detect such situation. So here just assign
@@ -271,7 +323,10 @@ impl crate::pool::Runner for Runner {
                         extras.remote = Some((&*l.get()).weak_remote());
                     })
                 }
-                match task.status.compare_exchange(POLLING, IDLE, SeqCst, SeqCst) {
+                match task
+                    .status()
+                    .compare_exchange(POLLING, IDLE, SeqCst, SeqCst)
+                {
                     Ok(_) => return false,
                     Err(NOTIFIED) => {
                         let need_reschedule = NEED_RESCHEDULE.with(|r| r.replace(false));

--- a/src/task/future.rs
+++ b/src/task/future.rs
@@ -92,7 +92,7 @@ impl Drop for TaskCell {
             }
         }
         atomic::fence(Acquire);
-        unsafe { ptr::drop_in_place(self.0.as_ptr()) };
+        drop(unsafe { Box::from_raw(self.0.as_ptr()) });
     }
 }
 


### PR DESCRIPTION
It needs two allocations to create a future `TaskCell` (one for the boxed future and one for the `Arc`). But in theory, only one allocation is needed, we can put the future together with the reference counter.

This PR is an attemp to reduce one allocation when spawning a future. 

## Benchmark

The benchmark result varies a bit on AMD and Intel CPUs. The improvement on Intel CPUs is larger. But generally the performance improves a lot.


Intel CPU (Broadwell architecture):

```
hained_spawn/yatp::future/256                                                                            
                        time:   [320.11 us 325.44 us 330.77 us]
                        change: [-16.766% -14.984% -13.236%] (p = 0.00 < 0.05)
                        Performance has improved.

chained_spawn/yatp::future::multilevel/256                                                                            
                        time:   [714.11 us 721.86 us 729.12 us]
                        change: [-9.1268% -7.6689% -6.2970%] (p = 0.00 < 0.05)
                        Performance has improved.

chained_spawn/yatp::future/512                                                                            
                        time:   [645.12 us 654.96 us 664.91 us]
                        change: [-13.688% -10.933% -7.4314%] (p = 0.00 < 0.05)
                        Performance has improved.

chained_spawn/yatp::future::multilevel/512                                                                             
                        time:   [1.4204 ms 1.4364 ms 1.4530 ms]
                        change: [-9.2218% -7.9877% -6.8580%] (p = 0.00 < 0.05)
                        Performance has improved.

chained_spawn/yatp::future/1024                                                                             
                        time:   [1.2643 ms 1.2847 ms 1.3045 ms]
                        change: [-17.206% -15.192% -13.257%] (p = 0.00 < 0.05)
                        Performance has improved.

chained_spawn/yatp::future::multilevel/1024                                                                             
                        time:   [2.7879 ms 2.8175 ms 2.8481 ms]
                        change: [-5.8462% -4.2189% -2.4824%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future/256                                                                             
                        time:   [541.62 us 562.19 us 584.14 us]
                        change: [-17.698% -13.384% -9.1931%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future::multilevel/256                                                                             
                        time:   [934.63 us 989.69 us 1.0481 ms]
                        change: [-14.833% -7.3358% +0.8149%] (p = 0.08 > 0.05)
                        No change in performance detected.

ping_pong/yatp::future/512                                                                             
                        time:   [1.1379 ms 1.1989 ms 1.2707 ms]
                        change: [-15.509% -10.600% -4.8128%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future::multilevel/512                                                                            
                        time:   [1.5878 ms 1.7102 ms 1.8519 ms]
                        change: [-11.634% -3.1553% +7.2989%] (p = 0.51 > 0.05)
                        No change in performance detected.

ping_pong/yatp::future/1024                                                                             
                        time:   [1.8029 ms 1.8493 ms 1.8967 ms]
                        change: [-25.694% -21.901% -17.945%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future::multilevel/1024                                                                            
                        time:   [3.2063 ms 3.4405 ms 3.7010 ms]
                        change: [-20.380% -11.576% -1.4083%] (p = 0.03 < 0.05)
                        Performance has improved.
```

AMD CPU (Zen3):

```
chained_spawn/yatp::future/256                                                                            
                        time:   [135.65 us 138.50 us 140.52 us]
                        change: [-5.9478% -2.5318% +1.0341%] (p = 0.17 > 0.05)
                        No change in performance detected.

chained_spawn/yatp::future::multilevel/256                                                                            
                        time:   [347.79 us 348.56 us 349.37 us]
                        change: [-5.1074% -3.4979% -2.0763%] (p = 0.00 < 0.05)
                        Performance has improved.

chained_spawn/yatp::future/512                                                                            
                        time:   [268.32 us 271.67 us 274.19 us]
                        change: [-9.1894% -7.1292% -5.0224%] (p = 0.00 < 0.05)
                        Performance has improved.

chained_spawn/yatp::future::multilevel/512                                                                            
                        time:   [682.44 us 684.55 us 686.96 us]
                        change: [-4.4316% -2.6463% -1.0859%] (p = 0.00 < 0.05)
                        Performance has improved.

chained_spawn/yatp::future/1024                                                                            
                        time:   [534.57 us 539.47 us 543.10 us]
                        change: [-9.5112% -7.3240% -5.4031%] (p = 0.00 < 0.05)
                        Performance has improved.

chained_spawn/yatp::future::multilevel/1024                                                                             
                        time:   [1.3547 ms 1.3590 ms 1.3634 ms]
                        change: [-4.1776% -2.9282% -1.8075%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future/256                                                                            
                        time:   [160.72 us 164.39 us 168.04 us]
                        change: [-20.615% -17.699% -14.543%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future::multilevel/256                                                                            
                        time:   [938.01 us 944.54 us 951.49 us]
                        change: [-8.5092% -6.3584% -4.6114%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future/512                                                                            
                        time:   [299.33 us 304.79 us 310.39 us]
                        change: [-19.910% -17.778% -15.550%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future::multilevel/512                                                                             
                        time:   [1.7924 ms 1.8224 ms 1.8491 ms]
                        change: [-12.183% -10.088% -8.4730%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future/1024                                                                            
                        time:   [580.94 us 591.65 us 601.87 us]
                        change: [-19.182% -17.125% -15.031%] (p = 0.00 < 0.05)
                        Performance has improved.

ping_pong/yatp::future::multilevel/1024                                                                             
                        time:   [3.8410 ms 3.8641 ms 3.8859 ms]
                        change: [-6.3105% -5.3388% -4.1879%] (p = 0.00 < 0.05)
                        Performance has improved.
```