### PR TITLE
Run address sanitizer on CI

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -77,4 +77,4 @@ jobs:
           toolchain: nightly
           override: true
       - name: Run address sanitizer on benchmarks
-        run: cargo bench yatp --target x86_64-unknown-linux-gnu --all --all-features -- --test
+        run: cargo bench yatp -Zbuild-std --target x86_64-unknown-linux-gnu --all --all-features -- --test

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -76,5 +76,6 @@ jobs:
         with:
           toolchain: nightly
           override: true
+          components: rust-src
       - name: Run address sanitizer on benchmarks
         run: cargo bench yatp -Zbuild-std --target x86_64-unknown-linux-gnu --all --all-features -- --test

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -77,4 +77,4 @@ jobs:
           toolchain: nightly
           override: true
       - name: Run address sanitizer on benchmarks
-        run: cargo bench --target x86_64-unknown-linux-gnu --all --all-features -- --test
+        run: cargo bench yatp --target x86_64-unknown-linux-gnu --all --all-features -- --test

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -61,3 +61,20 @@ jobs:
           override: true
       - name: Bench with --all-features
         run: cargo bench --all --all-features -- --test
+  sanitizer:
+    name: address-sanitizer-benchmark-ubuntu-latest-nightly
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+      RUSTFLAGS: "-D warnings -Z sanitizer=address"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Run address sanitizer on benchmarks
+        run: cargo bench --target x86_64-unknown-linux-gnu --all --all-features -- --test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,4 +97,4 @@ jobs:
           toolchain: nightly
           override: true
       - name: Run address sanitizer on tests
-        run: cargo test --target x86_64-unknown-linux-gnu --all --all-features -- --nocapture
+        run: cargo test -Zbuild-std --target x86_64-unknown-linux-gnu --all --all-features -- --nocapture

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -96,5 +96,6 @@ jobs:
         with:
           toolchain: nightly
           override: true
+          components: rust-src
       - name: Run address sanitizer on tests
         run: cargo test -Zbuild-std --target x86_64-unknown-linux-gnu --all --all-features -- --nocapture

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,3 +81,20 @@ jobs:
           override: true
       - name: Test with --all-features
         run: cargo test --all --all-features -- --nocapture
+  sanitizer:
+    name: address-sanitizer-ubuntu-latest-nightly
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+      RUST_BACKTRACE: 1
+      RUSTFLAGS: "-D warnings -Z sanitizer=address"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+      - name: Run address sanitizer on tests
+        run: cargo test --target x86_64-unknown-linux-gnu --all --all-features -- --nocapture


### PR DESCRIPTION
A lot of unsafe code is used to implement a future executor. It is better to add the address sanitizer to CI to reduce possible memory errors.