### PR TITLE
Support dynamically scaling workers of the pool (#60)

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -34,6 +34,15 @@ impl<T: TaskCell + Send> ThreadPool<T> {
         self.remote.spawn(t);
     }
 
+    /// Scale workers of the thread pool, the new thread count should be
+    /// smaller than the max_thread_count, otherwise it will become no-op
+    /// and return false.
+    ///
+    /// If the pool is shutdown, it becomes no-op.
+    pub fn scale_workers(&self, new_thread_count: usize) -> bool {
+        self.remote.scale_workers(new_thread_count)
+    }
+
     /// Shutdowns the pool.
     ///
     /// Closes the queue and wait for all threads to exit.

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -5,15 +5,22 @@ use crate::pool::worker::WorkerThread;
 use crate::pool::{CloneRunnerBuilder, Local, Remote, Runner, RunnerBuilder, ThreadPool};
 use crate::queue::{self, multilevel, LocalQueue, QueueType, TaskCell};
 use crate::task::{callback, future};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
 use std::thread;
 use std::time::Duration;
 
 /// Configuration for schedule algorithm.
-#[derive(Clone)]
 pub struct SchedConfig {
     /// The maximum number of running threads at the same time.
     pub max_thread_count: usize,
+    /// The core number of running threads at the same time. It
+    /// is defined as the AtomicUsize because it needs to be used
+    /// to scale the number of workers at runtime, and the adjustable
+    /// range is min_thread_count to max_thread_count.
+    pub core_thread_count: AtomicUsize,
     /// The minimum number of running threads at the same time.
     pub min_thread_count: usize,
     /// The maximum tries to rerun an unfinished task before pushing
@@ -35,12 +42,28 @@ impl Default for SchedConfig {
     fn default() -> SchedConfig {
         SchedConfig {
             max_thread_count: num_cpus::get(),
+            core_thread_count: AtomicUsize::new(0),
             min_thread_count: 1,
             max_inplace_spin: 4,
             max_idle_time: Duration::from_millis(1),
             max_wait_time: Duration::from_millis(1),
             wake_backoff: Duration::from_millis(1),
             alloc_slot_backoff: Duration::from_millis(2),
+        }
+    }
+}
+
+impl Clone for SchedConfig {
+    fn clone(&self) -> Self {
+        SchedConfig {
+            max_thread_count: self.max_thread_count,
+            min_thread_count: self.min_thread_count,
+            core_thread_count: AtomicUsize::new(self.core_thread_count.load(Ordering::SeqCst)),
+            max_inplace_spin: self.max_inplace_spin,
+            max_idle_time: self.max_idle_time,
+            max_wait_time: self.max_wait_time,
+            wake_backoff: self.wake_backoff,
+            alloc_slot_backoff: self.alloc_slot_backoff,
         }
     }
 }
@@ -134,6 +157,19 @@ impl Builder {
         self
     }
 
+    /// Sets the number of threads that can participate in being scheduled
+    /// by `Remote` at the same time. It will be checked when building the
+    /// queue, if this value exceeds `max_thread_count`, it will be adjusted
+    /// to `max_thread_count`.
+    pub fn core_thread_count(&mut self, count: usize) -> &mut Self {
+        if count > 0 {
+            self.sched_config
+                .core_thread_count
+                .store(count, Ordering::SeqCst);
+        }
+        self
+    }
+
     /// Sets the maximum tries to rerun an unfinished task before pushing
     /// back to queue.
     pub fn max_inplace_spin(&mut self, count: usize) -> &mut Self {
@@ -204,6 +240,12 @@ impl Builder {
         T: TaskCell + Send,
     {
         assert!(self.sched_config.min_thread_count <= self.sched_config.max_thread_count);
+        let core_thread_count = self.sched_config.core_thread_count.load(Ordering::SeqCst);
+        if core_thread_count == 0 || core_thread_count > self.sched_config.max_thread_count {
+            self.sched_config
+                .core_thread_count
+                .store(self.sched_config.max_thread_count, Ordering::SeqCst);
+        }
         let (injector, local_queues) = queue::build(queue_type, self.sched_config.max_thread_count);
         let core = Arc::new(QueueCore::new(injector, self.sched_config.clone()));
 

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -132,7 +132,7 @@ impl<T> QueueCore<T> {
 
     /// Scale workers.
     pub fn scale_workers(&self, new_thread_count: usize) -> bool {
-        let _ = self.l.lock().unwrap();
+        let _l = self.l.lock().unwrap();
         if new_thread_count < self.config.min_thread_count
             || new_thread_count > self.config.max_thread_count
         {

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -82,7 +82,7 @@ impl<T> QueueCore<T> {
         let addr = self as *const QueueCore<T> as usize;
         unsafe {
             parking_lot_core::unpark_all(addr, UnparkToken(source));
-            parking_lot_core::unpark_all(addr | 1, UnparkToken(source));
+            parking_lot_core::unpark_all(addr + 1, UnparkToken(source));
         }
     }
 
@@ -145,7 +145,7 @@ impl<T> QueueCore<T> {
             .swap(new_thread_count, Ordering::SeqCst);
         let gap = new_thread_count as isize - current_thread_count as isize;
         if gap > 0 {
-            let addr = self as *const QueueCore<T> as usize | 1;
+            let addr = self as *const QueueCore<T> as usize + 1;
             for _ in 0..gap {
                 unsafe {
                     parking_lot_core::unpark_one(addr, |_| UnparkToken(0));
@@ -380,7 +380,7 @@ impl<T: TaskCell + Send> Local<T> {
 
     /// Sleep if the current worker is not runnable
     pub(crate) fn sleep(&mut self) {
-        let address = &*self.core as *const QueueCore<T> as usize | 1;
+        let address = &*self.core as *const QueueCore<T> as usize + 1;
         let id = self.id;
 
         let res = unsafe {

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -81,8 +81,10 @@ where
 mod tests {
     use super::*;
     use crate::pool::spawn::*;
+    use crate::pool::SchedConfig;
     use crate::queue::QueueType;
     use crate::task::callback;
+    use std::sync::atomic::AtomicUsize;
     use std::sync::*;
     use std::time::*;
 
@@ -147,7 +149,9 @@ mod tests {
         };
         let metrics = r.metrics.clone();
         let mut expected_metrics = Metrics::default();
-        let (injector, mut locals) = build_spawn(QueueType::SingleLevel, Default::default());
+        let mut config: SchedConfig = Default::default();
+        config.core_thread_count = AtomicUsize::new(config.max_thread_count);
+        let (injector, mut locals) = build_spawn(QueueType::SingleLevel, config);
         let th = WorkerThread::new(locals.remove(0), r);
         let handle = std::thread::spawn(move || {
             th.run();

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -58,11 +58,10 @@ where
             self.runner.reentrant_end(&mut self.local);
 
             // If this worker should go to sleep, spawn all futures to remote
-            while let Some(t) = self.local.pop(false) {
-                if self.local.core().is_shutdown() {
-                    continue;
+            if !self.local.core().is_shutdown() {
+                while let Some(t) = self.local.pop(false) {
+                    self.local.spawn_remote(t.task_cell)
                 }
-                self.local.spawn_remote(t.task_cell)
             }
 
             // If pool already shutdown, drain all futures in the queue

--- a/src/queue.rs
+++ b/src/queue.rs
@@ -93,10 +93,10 @@ impl<T: TaskCell + Send> LocalQueue<T> {
 
     /// Gets a task cell from the queue. Returns `None` if there is no task cell
     /// available.
-    pub fn pop(&mut self) -> Option<Pop<T>> {
+    pub fn pop(&mut self, need_steal: bool) -> Option<Pop<T>> {
         match &mut self.0 {
-            LocalQueueInner::SingleLevel(q) => q.pop(),
-            LocalQueueInner::Multilevel(q) => q.pop(),
+            LocalQueueInner::SingleLevel(q) => q.pop(need_steal),
+            LocalQueueInner::Multilevel(q) => q.pop(need_steal),
         }
     }
 

--- a/src/queue/single_level.rs
+++ b/src/queue/single_level.rs
@@ -57,7 +57,7 @@ where
         self.local_queue.push(task_cell);
     }
 
-    pub fn pop(&mut self) -> Option<Pop<T>> {
+    pub fn pop(&mut self, mut need_steal: bool) -> Option<Pop<T>> {
         fn into_pop<T>(mut t: T, from_local: bool) -> Pop<T>
         where
             T: TaskCell,
@@ -73,12 +73,11 @@ where
         if let Some(t) = self.local_queue.pop() {
             return Some(into_pop(t, true));
         }
-        let mut need_retry = true;
-        while need_retry {
-            need_retry = false;
+        while need_steal {
+            need_steal = false;
             match self.injector.steal_batch_and_pop(&self.local_queue) {
                 Steal::Success(t) => return Some(into_pop(t, false)),
-                Steal::Retry => need_retry = true,
+                Steal::Retry => need_steal = true,
                 _ => {}
             }
             if !self.stealers.is_empty() {
@@ -89,7 +88,7 @@ where
                             found = Some((idx, into_pop(t, false)));
                             break;
                         }
-                        Steal::Retry => need_retry = true,
+                        Steal::Retry => need_steal = true,
                         _ => {}
                     }
                 }
@@ -184,7 +183,7 @@ mod tests {
         let (injector, mut locals) = super::create(1);
         injector.push(MockCell::new(0));
         thread::sleep(SLEEP_DUR);
-        let schedule_time = locals[0].pop().unwrap().schedule_time;
+        let schedule_time = locals[0].pop(true).unwrap().schedule_time;
         assert!(schedule_time.elapsed() >= SLEEP_DUR);
     }
 
@@ -195,10 +194,10 @@ mod tests {
             injector.push(MockCell::new(i));
         }
         let sum: i32 = (0..100)
-            .map(|_| locals[2].pop().unwrap().task_cell.value)
+            .map(|_| locals[2].pop(true).unwrap().task_cell.value)
             .sum();
         assert_eq!(sum, (0..100).sum());
-        assert!(locals.iter_mut().all(|c| c.pop().is_none()));
+        assert!(locals.iter_mut().all(|c| c.pop(true).is_none()));
     }
 
     #[test]
@@ -213,10 +212,10 @@ mod tests {
         }
         assert!(injector.0.steal_batch(&locals[1].local_queue).is_success());
         let sum: i32 = (0..100)
-            .map(|_| locals[2].pop().unwrap().task_cell.value)
+            .map(|_| locals[2].pop(true).unwrap().task_cell.value)
             .sum();
         assert_eq!(sum, (0..100).sum());
-        assert!(locals.iter_mut().all(|c| c.pop().is_none()));
+        assert!(locals.iter_mut().all(|c| c.pop(true).is_none()));
     }
 
     #[test]
@@ -231,7 +230,7 @@ mod tests {
             .map(|mut consumer| {
                 let sum = sum.clone();
                 thread::spawn(move || {
-                    while let Some(pop) = consumer.pop() {
+                    while let Some(pop) = consumer.pop(true) {
                         sum.fetch_add(pop.task_cell.value, Ordering::SeqCst);
                     }
                 })

--- a/src/task/callback.rs
+++ b/src/task/callback.rs
@@ -204,7 +204,7 @@ mod tests {
         );
         assert_eq!(rx.recv().unwrap(), 42);
         assert_eq!(rx.recv().unwrap(), 42);
-        assert!(locals[0].pop().is_none());
+        assert!(locals[0].pop(true).is_none());
         assert!(rx.recv().is_err());
     }
 
@@ -230,7 +230,7 @@ mod tests {
         );
         assert_eq!(rx.recv().unwrap(), 42);
         assert_eq!(rx.recv().unwrap(), 42);
-        assert!(locals[0].pop().is_some());
+        assert!(locals[0].pop(true).is_some());
         assert!(rx.recv().is_err());
     }
 }

--- a/src/task/future.rs
+++ b/src/task/future.rs
@@ -476,7 +476,7 @@ mod tests {
 
         /// Run `Runner::handle` once.
         fn handle_once(&mut self) {
-            if let Some(t) = self.locals[0].pop() {
+            if let Some(t) = self.locals[0].pop(true) {
                 let runner = self.runner.clone();
                 runner.borrow_mut().handle(&mut self.locals[0], t.task_cell);
             }


### PR DESCRIPTION
This Feature Request description and Technical proposal can be seen here: #60 

Tests that have been run, the test env is 
- IDC physical machine (CentOS Linux release 8.4.2105/4.18.0-305.10.2.el8_4.x86_64)
- WSL2 (AMD bullseye/sid/5.15.0-microsoft-standard-WSL2)

Testcases:

``` sh
#!/bin/bash -e

while true
do
        cargo bench --all -- --test
        cargo bench --all --all-features -- --test
        cargo test --all -- --nocapture
        cargo test --all --all-features -- --nocapture
done
```

- Ran `cargo bench --all -- --test` in a shell loop, will exist if  failed: passed with 26 success, 4 ignored, tested 50+ times

``` sh
test queue::multilevel::tests::test_get_elapsed_deadlock ... ignored
test task::future::tests::test_no_preemptive_task ... ignored
test task::future::tests::test_repoll_limit ... ignored
test task::future::tests::test_reschedule ... ignored
```

- Ran `cargo bench --all --all-features -- --test` in a shell loop, will exist if  failed: passed with 30(all) success. tested 50+ times

- I wrote a system testcase: [test-yatp](https://github.com/ethercflow/test-yatp), and had ran for a few hours. 

The test logic is simple:

``` rust
fn scale_workers() {
    let pool = Builder::new("SP")
        .max_thread_count(16)
        .core_thread_count(4)
        .build_callback_pool();
    let handler = pool.remote().clone();
    let builder = thread::Builder::new().name("wl".to_string());
    builder
        .spawn(move || {
            loop {
                let (tx, rx) = mpsc::channel();
                // A bunch of tasks should be executed correctly.
                let cases: Vec<_> = (10..100000000).collect();
                for id in &cases {
                    let t = tx.clone();
                    let id = *id;
                    handler.spawn(move |_: &mut Handle<'_>| t.send(id).unwrap());
                }
                let mut ans = vec![];
                for _ in 10..100000000 {
                    let r = rx.recv_timeout(Duration::from_secs(1)).unwrap();
                    ans.push(r);
                }
                ans.sort();
                assert_eq!(cases, ans);
                println!("finish one loop");
            }
        })
        .unwrap();
    loop {
        let mut rng = rand::thread_rng();
        let new_thread_count = rng.gen_range(1..16);
        println!("scale workers to {}", new_thread_count);
        pool.remote().scale_workers(new_thread_count);
        thread::sleep(Duration::from_secs(10));
    }
}
```

While running, execute the `pidstat -G yatp -t 1` command to observe that the number of threads running is in line with expectations:

``` sh
➜  test-yatp git:(main) ./target/release/test-yatp
scale workers to 8
scale workers to 14
scale workers to 9
```

``` sh
00:57:19      UID      TGID       TID    %usr %system  %guest   %wait    %CPU   CPU  Command
00:57:20        0   3950591         -  785.00   77.00    0.00    0.00  862.00    17  test-yatp
00:57:20        0         -   3950592   89.00    6.00    0.00    0.00   95.00     6  |__SP-0
00:57:20        0         -   3950593   87.00    8.00    0.00    0.00   95.00     2  |__SP-1
00:57:20        0         -   3950594   90.00    6.00    0.00    0.00   96.00     7  |__SP-2
00:57:20        0         -   3950595   87.00    9.00    0.00    0.00   96.00    10  |__SP-3
00:57:20        0         -   3950604   88.00    8.00    0.00    0.00   96.00    39  |__SP-12
00:57:20        0         -   3950605   88.00    8.00    0.00    0.00   96.00    31  |__SP-13
00:57:20        0         -   3950606   87.00    8.00    0.00    0.00   95.00    33  |__SP-14
00:57:20        0         -   3950607   87.00    8.00    0.00    0.00   95.00    21  |__SP-15
00:57:20        0         -   3950608   83.00   16.00    0.00    0.00   99.00    25  |__wl

00:57:20      UID      TGID       TID    %usr %system  %guest   %wait    %CPU   CPU  Command
00:57:21        0   3950591         -  797.00  149.00    0.00    0.00  946.00    17  test-yatp
00:57:21        0         -   3950592   75.00   13.00    0.00    0.00   88.00    21  |__SP-0
00:57:21        0         -   3950593   76.00   10.00    0.00    0.00   86.00     7  |__SP-1
00:57:21        0         -   3950594   75.00   11.00    0.00    1.00   86.00    31  |__SP-2
00:57:21        0         -   3950595   75.00   11.00    0.00    0.00   86.00    10  |__SP-3
00:57:21        0         -   3950596   21.00    4.00    0.00    0.00   25.00    29  |__SP-4
00:57:21        0         -   3950597   19.00    5.00    0.00    0.00   24.00    20  |__SP-5
00:57:21        0         -   3950598   20.00    5.00    0.00    0.00   25.00    33  |__SP-6
00:57:21        0         -   3950599   19.00    5.00    0.00    0.00   24.00    13  |__SP-7
00:57:21        0         -   3950600   20.00    4.00    0.00    0.00   24.00    35  |__SP-8
00:57:21        0         -   3950602   20.00    4.00    0.00    0.00   24.00     9  |__SP-10
00:57:21        0         -   3950604   77.00   10.00    0.00    0.00   87.00    39  |__SP-12
00:57:21        0         -   3950605   75.00   11.00    0.00    0.00   86.00     3  |__SP-13
00:57:21        0         -   3950606   75.00   12.00    0.00    0.00   87.00     1  |__SP-14
00:57:21        0         -   3950607   75.00   11.00    0.00    0.00   86.00    23  |__SP-15
00:57:21        0         -   3950608   69.00   32.00    0.00    0.00  101.00    25  |__wl

00:57:34      UID      TGID       TID    %usr %system  %guest   %wait    %CPU   CPU  Command
00:57:35        0   3950591         -  829.00  100.00    0.00    0.00  929.00    21  test-yatp
00:57:35        0         -   3950592   84.00    8.00    0.00    0.00   92.00    30  |__SP-0
00:57:35        0         -   3950594   83.00   10.00    0.00    0.00   93.00    15  |__SP-2
00:57:35        0         -   3950595   85.00    8.00    0.00    0.00   93.00    17  |__SP-3
00:57:35        0         -   3950597   83.00    9.00    0.00    1.00   92.00     0  |__SP-5
00:57:35        0         -   3950599   85.00    7.00    0.00    0.00   92.00    29  |__SP-7
00:57:35        0         -   3950600   82.00   10.00    0.00    0.00   92.00    34  |__SP-8
00:57:35        0         -   3950602   83.00    9.00    0.00    0.00   92.00    25  |__SP-10
00:57:35        0         -   3950606   85.00    8.00    0.00    0.00   93.00    23  |__SP-14
00:57:35        0         -   3950607   82.00   10.00    0.00    1.00   92.00     1  |__SP-15
00:57:35        0         -   3950608   78.00   19.00    0.00    0.00   97.00    31  |__wl
^C
```

 It does make sense?



Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>