### PR TITLE
Support dynamically scaling workers of the pool

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -34,22 +34,24 @@ impl<T: TaskCell + Send> ThreadPool<T> {
         self.remote.spawn(t);
     }
 
-    /// Scale workers of the thread pool, the new thread count should be less
-    /// than or equal to the max_thread_count, otherwise it will become no-op
-    /// and return false.
-    ///
-    /// If the pool is shutdown, it becomes no-op.
+    /// Scale workers of the thread pool, the adjustable range is `min_thread_count`
+    /// to `max_thread_count`, if this value exceeds `max_thread_count` or zero, it
+    /// will be adjusted to `max_thread_count`, if this value is between zero and
+    /// `min_thread_count`, it will be adjusted to `min_thread_count`.
     ///
     /// Notice:
     /// 1. The effect of scaling may be delayed, eg:
-    ///    - Threads run long-term tasks, resulting in inability to scale down in time,
-    ///      until they have no task to process and can sleep;
-    ///    - Scaling up relies on spawning tasks to the thread pool to unpark new threads,
-    ///      so the delay depends on the time interval between scale and spawn;
-    /// 2. If lots of tasks have been spawned before start, all threads (max_thread_count)
-    ///    will run until they can sleep, then scheduled based on core_thread_count;
-    pub fn scale_workers(&self, new_thread_count: usize) -> bool {
-        self.remote.scale_workers(new_thread_count)
+    ///    - Threads run long-term tasks, resulting in inability to scale down in
+    ///      time, until they have no task to process and can sleep;
+    ///    - Scaling up relies on spawning tasks to the thread pool to unpark new
+    ///      threads, so the delay depends on the time interval between scale and
+    ///      spawn;
+    /// 2. If lots of tasks have been spawned before start, there may be more than
+    ///    `core_thread_count` (max up to `max_thread_count`) threads running at a
+    ///    moment until they can sleep (no tasks to run), then scheduled based on
+    ///    `core_thread_count`;
+    pub fn scale_workers(&self, new_thread_count: usize) {
+        self.remote.scale_workers(new_thread_count);
     }
 
     /// Shutdowns the pool.

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -34,6 +34,15 @@ impl<T: TaskCell + Send> ThreadPool<T> {
         self.remote.spawn(t);
     }
 
+    /// Scale workers of the thread pool, the new thread count should be
+    /// smaller than the max_thread_count, otherwise it will become no-op
+    /// and return false.
+    ///
+    /// If the pool is shutdown, it becomes no-op.
+    pub fn scale_workers(&self, new_thread_count: usize) -> bool {
+        self.remote.scale_workers(new_thread_count)
+    }
+
     /// Shutdowns the pool.
     ///
     /// Closes the queue and wait for all threads to exit.

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -5,15 +5,22 @@ use crate::pool::worker::WorkerThread;
 use crate::pool::{CloneRunnerBuilder, Local, Remote, Runner, RunnerBuilder, ThreadPool};
 use crate::queue::{self, multilevel, LocalQueue, QueueType, TaskCell};
 use crate::task::{callback, future};
-use std::sync::{Arc, Mutex};
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Arc, Mutex,
+};
 use std::thread;
 use std::time::Duration;
 
 /// Configuration for schedule algorithm.
-#[derive(Clone)]
 pub struct SchedConfig {
     /// The maximum number of running threads at the same time.
     pub max_thread_count: usize,
+    /// The core number of running threads at the same time. It
+    /// is defined as the AtomicUsize because it needs to be used
+    /// to scale the number of workers at runtime, and the adjustable
+    /// range is min_thread_count to max_thread_count.
+    pub core_thread_count: AtomicUsize,
     /// The minimum number of running threads at the same time.
     pub min_thread_count: usize,
     /// The maximum tries to rerun an unfinished task before pushing
@@ -35,12 +42,28 @@ impl Default for SchedConfig {
     fn default() -> SchedConfig {
         SchedConfig {
             max_thread_count: num_cpus::get(),
+            core_thread_count: AtomicUsize::new(0),
             min_thread_count: 1,
             max_inplace_spin: 4,
             max_idle_time: Duration::from_millis(1),
             max_wait_time: Duration::from_millis(1),
             wake_backoff: Duration::from_millis(1),
             alloc_slot_backoff: Duration::from_millis(2),
+        }
+    }
+}
+
+impl Clone for SchedConfig {
+    fn clone(&self) -> Self {
+        SchedConfig {
+            max_thread_count: self.max_thread_count,
+            min_thread_count: self.min_thread_count,
+            core_thread_count: AtomicUsize::new(self.core_thread_count.load(Ordering::SeqCst)),
+            max_inplace_spin: self.max_inplace_spin,
+            max_idle_time: self.max_idle_time,
+            max_wait_time: self.max_wait_time,
+            wake_backoff: self.wake_backoff,
+            alloc_slot_backoff: self.alloc_slot_backoff,
         }
     }
 }
@@ -134,6 +157,19 @@ impl Builder {
         self
     }
 
+    /// Sets the number of threads that can participate in being scheduled
+    /// by `Remote` at the same time. It will be checked when building the
+    /// queue, if this value exceeds `max_thread_count`, it will be adjusted
+    /// to `max_thread_count`.
+    pub fn core_thread_count(&mut self, count: usize) -> &mut Self {
+        if count > 0 {
+            self.sched_config
+                .core_thread_count
+                .store(count, Ordering::SeqCst);
+        }
+        self
+    }
+
     /// Sets the maximum tries to rerun an unfinished task before pushing
     /// back to queue.
     pub fn max_inplace_spin(&mut self, count: usize) -> &mut Self {
@@ -204,6 +240,12 @@ impl Builder {
         T: TaskCell + Send,
     {
         assert!(self.sched_config.min_thread_count <= self.sched_config.max_thread_count);
+        let core_thread_count = self.sched_config.core_thread_count.load(Ordering::SeqCst);
+        if core_thread_count == 0 || core_thread_count > self.sched_config.max_thread_count {
+            self.sched_config
+                .core_thread_count
+                .store(self.sched_config.max_thread_count, Ordering::SeqCst);
+        }
         let (injector, local_queues) = queue::build(queue_type, self.sched_config.max_thread_count);
         let core = Arc::new(QueueCore::new(injector, self.sched_config.clone()));
 

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -159,8 +159,9 @@ impl Builder {
 
     /// Sets the number of threads that can participate in being scheduled
     /// by `Remote` at the same time. It will be checked when building the
-    /// queue, if this value exceeds `max_thread_count`, it will be adjusted
-    /// to `max_thread_count`.
+    /// queue, if this value exceeds `max_thread_count` or zero, it will be
+    /// adjusted to `max_thread_count`, if this value is between zero and
+    /// `min_thread_count` it will be adjusted to `min_thread_count`.
     pub fn core_thread_count(&mut self, count: usize) -> &mut Self {
         if count > 0 {
             self.sched_config
@@ -245,6 +246,10 @@ impl Builder {
             self.sched_config
                 .core_thread_count
                 .store(self.sched_config.max_thread_count, Ordering::SeqCst);
+        } else if core_thread_count < self.sched_config.min_thread_count {
+            self.sched_config
+                .core_thread_count
+                .store(self.sched_config.min_thread_count, Ordering::SeqCst);
         }
         let (injector, local_queues) = queue::build(queue_type, self.sched_config.max_thread_count);
         let core = Arc::new(QueueCore::new(injector, self.sched_config.clone()));

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -138,16 +138,15 @@ impl<T> QueueCore<T> {
     }
 
     /// Scale workers.
-    pub fn scale_workers(&self, new_thread_count: usize) -> bool {
-        if new_thread_count < self.config.min_thread_count
-            || new_thread_count > self.config.max_thread_count
-        {
-            return false;
+    pub fn scale_workers(&self, mut new_thread_count: usize) {
+        if new_thread_count == 0 || new_thread_count > self.config.max_thread_count {
+            new_thread_count = self.config.max_thread_count;
+        } else if new_thread_count < self.config.min_thread_count {
+            new_thread_count = self.config.min_thread_count;
         }
         self.config
             .core_thread_count
             .store(new_thread_count, Ordering::SeqCst);
-        true
     }
 }
 
@@ -185,7 +184,7 @@ impl<T: TaskCell + Send> Remote<T> {
     }
 
     /// Scales workers of the thread pool.
-    pub fn scale_workers(&self, new_thread_count: usize) -> bool {
+    pub fn scale_workers(&self, new_thread_count: usize) {
         self.core.scale_workers(new_thread_count)
     }
 

--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -7,7 +7,7 @@
 use crate::pool::SchedConfig;
 use crate::queue::{Extras, LocalQueue, Pop, TaskCell, TaskInjector, WithExtras};
 use fail::fail_point;
-use parking_lot_core::{ParkResult, ParkToken, UnparkToken};
+use parking_lot_core::{FilterOp, ParkResult, ParkToken, UnparkToken};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Weak,
@@ -56,13 +56,29 @@ impl<T> QueueCore<T> {
     /// the action.
     pub fn ensure_workers(&self, source: usize) {
         let cnt = self.active_workers.load(Ordering::SeqCst);
-        if (cnt >> WORKER_COUNT_SHIFT) >= self.config.max_thread_count || is_shutdown(cnt) {
+        if (cnt >> WORKER_COUNT_SHIFT) >= self.config.core_thread_count.load(Ordering::SeqCst)
+            || is_shutdown(cnt)
+        {
             return;
         }
 
         let addr = self as *const QueueCore<T> as usize;
+        let mut unparked_once = false;
+
         unsafe {
-            parking_lot_core::unpark_one(addr, |_| UnparkToken(source));
+            parking_lot_core::unpark_filter(
+                addr,
+                |p: ParkToken| {
+                    if !unparked_once && p.0 <= self.config.core_thread_count.load(Ordering::SeqCst)
+                    {
+                        unparked_once = true;
+                        FilterOp::Unpark
+                    } else {
+                        FilterOp::Skip
+                    }
+                },
+                |_| UnparkToken(source),
+            );
         }
     }
 
@@ -120,6 +136,19 @@ impl<T> QueueCore<T> {
             }
         }
     }
+
+    /// Scale workers.
+    pub fn scale_workers(&self, new_thread_count: usize) -> bool {
+        if new_thread_count < self.config.min_thread_count
+            || new_thread_count > self.config.max_thread_count
+        {
+            return false;
+        }
+        self.config
+            .core_thread_count
+            .store(new_thread_count, Ordering::SeqCst);
+        true
+    }
 }
 
 impl<T: TaskCell + Send> QueueCore<T> {
@@ -153,6 +182,11 @@ impl<T: TaskCell + Send> Remote<T> {
     pub fn spawn(&self, task: impl WithExtras<T>) {
         let t = task.with_extras(|| self.core.default_extras());
         self.core.push(0, t);
+    }
+
+    /// Scales workers of the thread pool.
+    pub fn scale_workers(&self, new_thread_count: usize) -> bool {
+        self.core.scale_workers(new_thread_count)
     }
 
     pub(crate) fn stop(&self) {

--- a/src/pool/tests.rs
+++ b/src/pool/tests.rs
@@ -175,6 +175,9 @@ fn test_scale_up_workers() {
         .core_thread_count(2)
         .build_callback_pool();
 
+    // Make sure all workers have run and gone to sleep before spawn new tasks
+    thread::sleep(Duration::from_secs(1));
+
     let mut sync_txs = vec![];
     // Block all runnable (`core_thread_count`) threads
     for _ in 0..2 {
@@ -198,7 +201,7 @@ fn test_scale_up_workers() {
     );
     // Scale up one worker
     pool.scale_workers(3);
-    // Due to the current implementation, the scale up cann't be triggered until a new
+    // Due to the current implementation, the scale up can't be triggered until a new
     // task has been spawned, so it should still time out
     assert_eq!(
         rx.recv_timeout(Duration::from_secs(1)),
@@ -238,6 +241,9 @@ fn test_scale_down_workers() {
         .core_thread_count(3)
         .build_callback_pool();
 
+    // Make sure all workers have run and gone to sleep before spawn new tasks
+    thread::sleep(Duration::from_secs(1));
+
     let mut sync_txs = vec![];
     // Block all runnable (`core_thread_count`) threads
     for _ in 0..3 {
@@ -261,7 +267,7 @@ fn test_scale_down_workers() {
 
     // Scale down two workers
     pool.scale_workers(1);
-    // Due to the current implementation, the scale down cann't be triggered until thread
+    // Due to the current implementation, the scale down can't be triggered until thread
     // finished tasks and go to sleep, so wake up them all to finish tasks first.
     for tx in sync_txs {
         tx.send(()).unwrap();

--- a/src/pool/tests.rs
+++ b/src/pool/tests.rs
@@ -167,3 +167,124 @@ fn test_shutdown_with_futures() {
         Err(mpsc::RecvTimeoutError::Disconnected)
     );
 }
+
+#[test]
+fn test_scale_up_workers() {
+    let pool = Builder::new("test_scale_up")
+        .max_thread_count(4)
+        .core_thread_count(2)
+        .build_callback_pool();
+
+    let mut sync_txs = vec![];
+    // Block all runnable (`core_thread_count`) threads
+    for _ in 0..2 {
+        let (tx, rx) = mpsc::sync_channel::<()>(0);
+        pool.spawn(move |_: &mut Handle<'_>| rx.recv().unwrap());
+        sync_txs.push(tx);
+    }
+
+    // Make sure all block tasks have been dispatched to `core_thread_count` threads,
+    // as the above block tasks may be pulled to one thread at once, then stealed
+    // by the other thread, which cause the below task is executed first.
+    thread::sleep(Duration::from_secs(1));
+
+    let (tx, rx) = mpsc::channel();
+    let tx1 = tx.clone();
+    pool.spawn(move |_: &mut Handle<'_>| tx1.send(1).unwrap());
+    // No runnable threads, so it should time out
+    assert_eq!(
+        rx.recv_timeout(Duration::from_secs(1)),
+        Err(mpsc::RecvTimeoutError::Timeout)
+    );
+    // Scale up one worker
+    pool.scale_workers(3);
+    // Due to the current implementation, the scale up cann't be triggered until a new
+    // task has been spawned, so it should still time out
+    assert_eq!(
+        rx.recv_timeout(Duration::from_secs(1)),
+        Err(mpsc::RecvTimeoutError::Timeout)
+    );
+    // Spawn a new task to trigger scale up
+    pool.spawn(move |_: &mut Handle<'_>| tx.send(2).unwrap());
+    // Spawn should success, and handle the two tasks by the spawned order
+    assert_eq!(Ok(1), rx.recv_timeout(Duration::from_secs(1)));
+    assert_eq!(Ok(2), rx.recv_timeout(Duration::from_secs(1)));
+
+    // Block the new scaled thread, to prove only scaled one thread
+    let (tx, rx) = mpsc::sync_channel::<()>(0);
+    pool.spawn(move |_: &mut Handle<'_>| rx.recv().unwrap());
+    sync_txs.push(tx);
+
+    let (tx, rx) = mpsc::channel();
+    pool.spawn(move |_: &mut Handle<'_>| tx.send(1).unwrap());
+    // The scaled thread has been blocked, no more runnable threads, so it should time out
+    assert_eq!(
+        rx.recv_timeout(Duration::from_secs(1)),
+        Err(mpsc::RecvTimeoutError::Timeout)
+    );
+
+    // Wake up the threads that were previously blocked by the task
+    for tx in sync_txs {
+        tx.send(()).unwrap();
+    }
+
+    pool.shutdown();
+}
+
+#[test]
+fn test_scale_down_workers() {
+    let pool = Builder::new("test_scale_down")
+        .max_thread_count(4)
+        .core_thread_count(3)
+        .build_callback_pool();
+
+    let mut sync_txs = vec![];
+    // Block all runnable (`core_thread_count`) threads
+    for _ in 0..3 {
+        let (tx, rx) = mpsc::sync_channel::<()>(0);
+        pool.spawn(move |_: &mut Handle<'_>| rx.recv().unwrap());
+        sync_txs.push(tx);
+    }
+
+    // Make sure all block tasks have been dispatched to `core_thread_count` threads,
+    // as the above block tasks may be pulled by one thread at once, then stealed
+    // by other threads, which will cause the below task is executed first.
+    thread::sleep(Duration::from_secs(1));
+
+    let (tx, rx) = mpsc::channel();
+    pool.spawn(move |_: &mut Handle<'_>| tx.send(1).unwrap());
+    // No runnable threads, so it should time out
+    assert_eq!(
+        rx.recv_timeout(Duration::from_secs(1)),
+        Err(mpsc::RecvTimeoutError::Timeout)
+    );
+
+    // Scale down two workers
+    pool.scale_workers(1);
+    // Due to the current implementation, the scale down cann't be triggered until thread
+    // finished tasks and go to sleep, so wake up them all to finish tasks first.
+    for tx in sync_txs {
+        tx.send(()).unwrap();
+    }
+
+    // Make sure all threads have gone to sleep before spawn a lot of new tasks
+    thread::sleep(Duration::from_secs(1));
+
+    let (tx, rx) = mpsc::channel();
+    // A bunch of tasks should be executed correctly, and as there's only one worker, the
+    // handled order should be the same as spawn order.
+    let cases: Vec<_> = (10..1000).collect();
+    for id in &cases {
+        let t = tx.clone();
+        let id = *id;
+        pool.spawn(move |_: &mut Handle<'_>| t.send(id).unwrap());
+    }
+    let mut ans = vec![];
+    for _ in 10..1000 {
+        let r = rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        ans.push(r);
+    }
+    assert_eq!(cases, ans);
+
+    pool.shutdown();
+}

--- a/src/pool/worker.rs
+++ b/src/pool/worker.rs
@@ -58,8 +58,10 @@ where
 mod tests {
     use super::*;
     use crate::pool::spawn::*;
+    use crate::pool::SchedConfig;
     use crate::queue::QueueType;
     use crate::task::callback;
+    use std::sync::atomic::AtomicUsize;
     use std::sync::*;
     use std::time::*;
 
@@ -124,7 +126,9 @@ mod tests {
         };
         let metrics = r.metrics.clone();
         let mut expected_metrics = Metrics::default();
-        let (injector, mut locals) = build_spawn(QueueType::SingleLevel, Default::default());
+        let mut config: SchedConfig = Default::default();
+        config.core_thread_count = AtomicUsize::new(config.max_thread_count);
+        let (injector, mut locals) = build_spawn(QueueType::SingleLevel, config);
         let th = WorkerThread::new(locals.remove(0), r);
         let handle = std::thread::spawn(move || {
             th.run();


### PR DESCRIPTION
Simplified implementation of [previous version](https://github.com/tikv/yatp/pull/61):

1. Unified use of one Queue to manage all threads;
2. Use `active_workers` to consider if it need to scale up as before;
3. Use `unpack_filter` instead of `unpack_one` to determine which thread to unpark by comparing `ParkToken(id)` and `core_thread_count`, only thread id not larger than this value can be unparked;
4. Restore runner and worker implementation;

Test scale with [test-yatp](https://github.com/ethercflow/test-yatp) as before.

The test logic is:

``` rust
fn scale_workers() {
    let pool = Builder::new("SP")
        .max_thread_count(16)
        .core_thread_count(4)
        .build_callback_pool();
    let handler = pool.remote().clone();
    let builder = thread::Builder::new().name("wl".to_string());
    builder
        .spawn(move || {
            loop {
                let (tx, rx) = mpsc::channel();
                // A bunch of tasks should be executed correctly.
                let cases: Vec<_> = (10..100000000).collect();
                for id in &cases {
                    let t = tx.clone();
                    let id = *id;
                    handler.spawn(move |_: &mut Handle<'_>| t.send(id).unwrap());
                }
                let mut ans = vec![];
                for _ in 10..100000000 {
                    let r = rx.recv_timeout(Duration::from_secs(1)).unwrap();
                    ans.push(r);
                }
                ans.sort();
                assert_eq!(cases, ans);
                println!("finish one loop");
            }
        })
        .unwrap();
    loop {
        let mut rng = rand::thread_rng();
        let new_thread_count = rng.gen_range(1..16);
        println!("scale workers to {}", new_thread_count);
        pool.remote().scale_workers(new_thread_count);
        thread::sleep(Duration::from_secs(10));
    }
}
```

While running, execute the `pidstat -G yatp -t 1` command to observe that the number of threads running is in line with expectations:

``` sh
➜  test-yatp git:(main) ./target/release/test-yatp
scale workers to 8
scale workers to 4
scale workers to 9
```

``` sh
00:57:19      UID      TGID       TID    %usr %system  %guest   %wait    %CPU   CPU  Command
00:57:20        0   3950591         -  785.00   77.00    0.00    0.00  862.00    17  test-yatp
00:57:20        0         -   3950592   89.00    6.00    0.00    0.00   95.00     6  |__SP-0
00:57:20        0         -   3950593   87.00    8.00    0.00    0.00   95.00     2  |__SP-1
00:57:20        0         -   3950594   90.00    6.00    0.00    0.00   96.00     7  |__SP-2
00:57:20        0         -   3950595   87.00    9.00    0.00    0.00   96.00    10  |__SP-3
00:57:20        0         -   3950604   88.00    8.00    0.00    0.00   96.00    39  |__SP-4
00:57:20        0         -   3950605   88.00    8.00    0.00    0.00   96.00    31  |__SP-5
00:57:20        0         -   3950606   87.00    8.00    0.00    0.00   95.00    33  |__SP-6
00:57:20        0         -   3950607   87.00    8.00    0.00    0.00   95.00    21  |__SP-7
00:57:20        0         -   3950608   83.00   16.00    0.00    0.00   99.00    25  |__wl

00:57:20      UID      TGID       TID    %usr %system  %guest   %wait    %CPU   CPU  Command
00:57:21        0   3950591         -  797.00  149.00    0.00    0.00  946.00    17  test-yatp
00:57:21        0         -   3950592   75.00   13.00    0.00    0.00   88.00    21  |__SP-0
00:57:21        0         -   3950593   76.00   10.00    0.00    0.00   86.00     7  |__SP-1
00:57:21        0         -   3950594   75.00   11.00    0.00    1.00   86.00    31  |__SP-2
00:57:21        0         -   3950595   75.00   11.00    0.00    0.00   86.00    10  |__SP-3
00:57:21        0         -   3950608   69.00   32.00    0.00    0.00  101.00    25  |__wl

00:57:34      UID      TGID       TID    %usr %system  %guest   %wait    %CPU   CPU  Command
00:57:35        0   3950591         -  829.00  100.00    0.00    0.00  929.00    21  test-yatp
00:57:35        0         -   3950592   84.00    8.00    0.00    0.00   92.00    30  |__SP-0
00:57:35        0         -   3950594   83.00   10.00    0.00    0.00   93.00    15  |__SP-1
00:57:35        0         -   3950595   85.00    8.00    0.00    0.00   93.00    17  |__SP-2
00:57:35        0         -   3950597   83.00    9.00    0.00    1.00   92.00     0  |__SP-3
00:57:35        0         -   3950599   85.00    7.00    0.00    0.00   92.00    29  |__SP-4
00:57:35        0         -   3950600   82.00   10.00    0.00    0.00   92.00    34  |__SP-5
00:57:35        0         -   3950602   83.00    9.00    0.00    0.00   92.00    25  |__SP-6
00:57:35        0         -   3950606   85.00    8.00    0.00    0.00   93.00    23  |__SP-7
00:57:35        0         -   3950607   82.00   10.00    0.00    1.00   92.00     1  |__SP-8
00:57:35        0         -   3950608   78.00   19.00    0.00    0.00   97.00    31  |__wl
^C
```

The bench cmp result is here:

![image](https://user-images.githubusercontent.com/38067786/153856812-b0f6ea8f-c105-478c-8ac1-f0036298e358.png)


Signed-off-by: Wenbo Zhang <ethercflow@gmail.com>