### PR TITLE
Add getters for fields in Extras

### DIFF
--- a/src/queue/extras.rs
+++ b/src/queue/extras.rs
@@ -4,7 +4,7 @@ use super::multilevel::ElapsedTime;
 
 use rand::prelude::*;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 /// The extras for the task cells pushed into a queue.
 #[derive(Debug, Clone)]
@@ -54,5 +54,27 @@ impl Extras {
             current_level: 0,
             fixed_level,
         }
+    }
+
+    /// Gets the instant when the task is scheduled.
+    pub fn schedule_time(&self) -> Option<Instant> {
+        self.schedule_time
+    }
+
+    /// Gets the identifier of the task.
+    pub fn task_id(&self) -> u64 {
+        self.task_id
+    }
+
+    /// Gets the time spent on handling this task.
+    pub fn running_time(&self) -> Option<Duration> {
+        self.running_time
+            .as_ref()
+            .map(|elapsed| elapsed.as_duration())
+    }
+
+    /// Gets the level of queue which this task comes from.
+    pub fn current_level(&self) -> u8 {
+        self.current_level
     }
 }

--- a/src/queue/multilevel.rs
+++ b/src/queue/multilevel.rs
@@ -357,7 +357,7 @@ impl LevelManager {
 pub(crate) struct ElapsedTime(AtomicU64);
 
 impl ElapsedTime {
-    fn as_duration(&self) -> Duration {
+    pub(crate) fn as_duration(&self) -> Duration {
         Duration::from_micros(self.0.load(Relaxed) as u64)
     }
 


### PR DESCRIPTION
This PR exposes fields from `Extras`. Then, the user can get the information such as `schedule_time` in their customized `Runner` and record them as metrics or log them.

The fields are exposed using getters, so the user is not allowed to modify them.