### PR TITLE
fix task total execute time tracker

### DIFF
--- a/src/queue/multilevel.rs
+++ b/src/queue/multilevel.rs
@@ -274,6 +274,9 @@ where
         let elapsed = begin.elapsed();
 
         task_running_time.inc_by(elapsed);
+        if let Some(ref running_time) = total_running_time {
+            running_time.inc_by(elapsed);
+        }
         self.task_poll_duration[level].observe(elapsed.as_secs_f64());
         let elapsed_us = elapsed.as_micros() as u64;
         if level == 0 {
@@ -282,9 +285,6 @@ where
         // set task execute time metrics
         if res {
             let exec_time = task_running_time.as_duration();
-            if let Some(ref running_time) = total_running_time {
-                running_time.inc_by(task_running_time.as_duration());
-            }
             let wait_time = start_time.elapsed().saturating_sub(exec_time);
             self.task_wait_duration.observe(wait_time.as_secs_f64());
             self.task_execute_duration.observe(exec_time.as_secs_f64());


### PR DESCRIPTION
Fix the bug that the task total execution time is not updated on time. The bug is introduced by #67.
This bug can affect the performance impact of big task for small tasks.
I test the performace impact by running sysbench oltp_read_only(--thread=50 --range-selects) as small tasks and run go-tpc tpch --sf=10 as big tasks.
Before: 
<img width="645" alt="before" src="https://user-images.githubusercontent.com/5196885/203267622-7c40d674-3599-4111-8fdf-746a4f645cc7.png">

After
<img width="646" alt="after" src="https://user-images.githubusercontent.com/5196885/203268038-24ab890e-23da-486d-b8bc-2a470c9b2083.png">

The throughput impact is much better and the tail latency is slightly better.