### PR TITLE
queue: support priority queue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/tikv/yatp/"
 
 [dependencies]
 crossbeam-deque = "0.8"
-crossbeam-skiplist = { git = "https://github.com/crossbeam-rs/crossbeam" }
+crossbeam-skiplist = "0.1"
 dashmap = "5.1"
 fail = "0.5"
 lazy_static = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/tikv/yatp/"
 [dependencies]
 crossbeam-deque = "0.8"
 crossbeam-skiplist = "0.1"
+crossbeam-utils = "0.8"
 dashmap = "5.1"
 fail = "0.5"
 lazy_static = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/tikv/yatp/"
 
 [dependencies]
 crossbeam-deque = "0.8"
+crossbeam-skiplist = { git = "https://github.com/crossbeam-rs/crossbeam" }
 dashmap = "5.1"
 fail = "0.5"
 lazy_static = "1"

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -7,7 +7,7 @@
 
 mod builder;
 mod runner;
-mod spawn;
+pub(crate) mod spawn;
 mod worker;
 
 pub use self::builder::{Builder, SchedConfig};

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -3,7 +3,7 @@
 use crate::pool::spawn::QueueCore;
 use crate::pool::worker::WorkerThread;
 use crate::pool::{CloneRunnerBuilder, Local, Remote, Runner, RunnerBuilder, ThreadPool};
-use crate::queue::{self, multilevel, LocalQueue, QueueType, TaskCell};
+use crate::queue::{self, multilevel, priority, LocalQueue, QueueType, TaskCell};
 use crate::task::{callback, future};
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -288,6 +288,17 @@ impl Builder {
         let queue_builder = multilevel::Builder::new(multilevel::Config::default());
         let runner_builder = queue_builder.runner_builder(fb);
         self.build_with_queue_and_runner(QueueType::Multilevel(queue_builder), runner_builder)
+    }
+
+    ///
+    pub fn build_priority_future_pool(
+        &self,
+        priority_priovider: Arc<dyn priority::TaskPriorityProvider>,
+    ) -> ThreadPool<future::TaskCell> {
+        let fb = CloneRunnerBuilder(future::Runner::default());
+        let queue_builder = priority::Builder::new(priority::Config::default(), priority_priovider);
+        let runner_builder = queue_builder.runner_builder(fb);
+        self.build_with_queue_and_runner(QueueType::Priority(queue_builder), runner_builder)
     }
 
     /// Spawns the thread pool immediately.

--- a/src/pool/builder.rs
+++ b/src/pool/builder.rs
@@ -290,13 +290,15 @@ impl Builder {
         self.build_with_queue_and_runner(QueueType::Multilevel(queue_builder), runner_builder)
     }
 
+    /// Spawn a priority future pool.
     ///
+    /// It setups the pool with priority queue. Caller must provide a `TaskPriorityProvider` implementation to generate the proper priority value for each spawned task.
     pub fn build_priority_future_pool(
         &self,
-        priority_priovider: Arc<dyn priority::TaskPriorityProvider>,
+        priority_provider: Arc<dyn priority::TaskPriorityProvider>,
     ) -> ThreadPool<future::TaskCell> {
         let fb = CloneRunnerBuilder(future::Runner::default());
-        let queue_builder = priority::Builder::new(priority::Config::default(), priority_priovider);
+        let queue_builder = priority::Builder::new(priority::Config::default(), priority_provider);
         let runner_builder = queue_builder.runner_builder(fb);
         self.build_with_queue_and_runner(QueueType::Priority(queue_builder), runner_builder)
     }

--- a/src/queue/extras.rs
+++ b/src/queue/extras.rs
@@ -105,7 +105,7 @@ impl Extras {
         &mut self.metadata
     }
 
-    /// Set the group name of this task.
+    /// Set the metadata of this task.
     pub fn set_metadata(&mut self, metadata: Vec<u8>) {
         self.metadata = metadata;
     }

--- a/src/queue/extras.rs
+++ b/src/queue/extras.rs
@@ -28,6 +28,8 @@ pub struct Extras {
     pub(crate) fixed_level: Option<u8>,
     /// Number of execute times
     pub(crate) exec_times: u32,
+    /// The task group id. Used in priority queue.
+    pub(crate) group_id: u64,
 }
 
 impl Extras {
@@ -43,6 +45,7 @@ impl Extras {
             current_level: 0,
             fixed_level: None,
             exec_times: 0,
+            group_id: 0,
         }
     }
 
@@ -62,9 +65,26 @@ impl Extras {
             task_id,
             running_time: Some(Arc::new(ElapsedTime::default())),
             total_running_time: None,
-            current_level: 0,
+            current_level: fixed_level.unwrap_or(0),
             fixed_level,
             exec_times: 0,
+            group_id: 0,
+        }
+    }
+
+    /// Creates an `Extra` for task cells pushed into a priority task queue
+    /// with custom settings.
+    pub fn new_priority(group_id: u64, task_id: u64, fixed_level: Option<u8>) -> Extras {
+        Extras {
+            start_time: Instant::now(),
+            schedule_time: None,
+            task_id,
+            running_time: None,
+            total_running_time: None,
+            current_level: fixed_level.unwrap_or(0),
+            fixed_level,
+            exec_times: 0,
+            group_id,
         }
     }
 
@@ -88,5 +108,10 @@ impl Extras {
     /// Gets the level of queue which this task comes from.
     pub fn current_level(&self) -> u8 {
         self.current_level
+    }
+
+    /// Gets the group id of this task
+    pub fn group_id(&self) -> u64 {
+        self.group_id
     }
 }

--- a/src/queue/extras.rs
+++ b/src/queue/extras.rs
@@ -28,8 +28,8 @@ pub struct Extras {
     pub(crate) fixed_level: Option<u8>,
     /// Number of execute times
     pub(crate) exec_times: u32,
-    /// The task group id. Used in priority queue.
-    pub(crate) group_id: u64,
+    /// The task group name. Used in priority queue.
+    pub(crate) group_name: String,
 }
 
 impl Extras {
@@ -45,7 +45,7 @@ impl Extras {
             current_level: 0,
             fixed_level: None,
             exec_times: 0,
-            group_id: 0,
+            group_name: String::new(),
         }
     }
 
@@ -68,23 +68,7 @@ impl Extras {
             current_level: fixed_level.unwrap_or(0),
             fixed_level,
             exec_times: 0,
-            group_id: 0,
-        }
-    }
-
-    /// Creates an `Extra` for task cells pushed into a priority task queue
-    /// with custom settings.
-    pub fn new_priority(group_id: u64, task_id: u64, fixed_level: Option<u8>) -> Extras {
-        Extras {
-            start_time: Instant::now(),
-            schedule_time: None,
-            task_id,
-            running_time: None,
-            total_running_time: None,
-            current_level: fixed_level.unwrap_or(0),
-            fixed_level,
-            exec_times: 0,
-            group_id,
+            group_name: String::new(),
         }
     }
 
@@ -110,8 +94,13 @@ impl Extras {
         self.current_level
     }
 
-    /// Gets the group id of this task
-    pub fn group_id(&self) -> u64 {
-        self.group_id
+    /// Gets the group name of this task.
+    pub fn group_name(&self) -> &str {
+        &self.group_name
+    }
+
+    /// Set the group name of this task.
+    pub fn set_group_name(&mut self, name: String) {
+        self.group_name = name;
     }
 }

--- a/src/queue/extras.rs
+++ b/src/queue/extras.rs
@@ -28,8 +28,9 @@ pub struct Extras {
     pub(crate) fixed_level: Option<u8>,
     /// Number of execute times
     pub(crate) exec_times: u32,
-    /// The task group name. Used in priority queue.
-    pub(crate) group_name: String,
+    /// Extra metadata of this task. User can use this field to store arbitrary data. It is useful 
+    /// in some case to implement more complext `TaskPriorityProvider` in the priority task queue.
+    pub(crate) metadata: Vec<u8>,
 }
 
 impl Extras {
@@ -45,7 +46,7 @@ impl Extras {
             current_level: 0,
             fixed_level: None,
             exec_times: 0,
-            group_name: String::new(),
+            metadata: Vec::new(),
         }
     }
 
@@ -68,7 +69,7 @@ impl Extras {
             current_level: fixed_level.unwrap_or(0),
             fixed_level,
             exec_times: 0,
-            group_name: String::new(),
+            metadata: Vec::new(),
         }
     }
 
@@ -94,13 +95,18 @@ impl Extras {
         self.current_level
     }
 
-    /// Gets the group name of this task.
-    pub fn group_name(&self) -> &str {
-        &self.group_name
+    /// Gets the metadata of this task.
+    pub fn metadata(&self) -> &[u8] {
+        &self.metadata
+    }
+
+    /// Gets the mutable metadata of this task.
+    pub fn metadata_mut(&mut self) -> &mut Vec<u8> {
+        &mut self.metadata
     }
 
     /// Set the group name of this task.
-    pub fn set_group_name(&mut self, name: String) {
-        self.group_name = name;
+    pub fn set_metadata(&mut self, metadata: Vec<u8>) {
+        self.metadata = metadata;
     }
 }

--- a/src/queue/extras.rs
+++ b/src/queue/extras.rs
@@ -28,7 +28,7 @@ pub struct Extras {
     pub(crate) fixed_level: Option<u8>,
     /// Number of execute times
     pub(crate) exec_times: u32,
-    /// Extra metadata of this task. User can use this field to store arbitrary data. It is useful 
+    /// Extra metadata of this task. User can use this field to store arbitrary data. It is useful
     /// in some case to implement more complext `TaskPriorityProvider` in the priority task queue.
     pub(crate) metadata: Vec<u8>,
 }

--- a/src/queue/multilevel.rs
+++ b/src/queue/multilevel.rs
@@ -405,7 +405,7 @@ impl LevelManager {
                 std::cmp::min(total_tasks / level_0_tasks, LEVEL_MAX_QUEUE_MAX_STEAL_SIZE)
             };
             self.max_level_queue_steal_size
-                .store(new_steal_count as usize, SeqCst);
+                .store(new_steal_count, SeqCst);
             for (i, c) in self.last_exec_tasks_per_level.iter().enumerate() {
                 c.set(cur_total_tasks_per_level[i]);
             }
@@ -457,7 +457,7 @@ pub(crate) struct ElapsedTime(AtomicU64);
 
 impl ElapsedTime {
     pub(crate) fn as_duration(&self) -> Duration {
-        Duration::from_micros(self.0.load(Relaxed) as u64)
+        Duration::from_micros(self.0.load(Relaxed))
     }
 
     pub(super) fn inc_by(&self, t: Duration) {

--- a/src/queue/multilevel.rs
+++ b/src/queue/multilevel.rs
@@ -23,7 +23,8 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{f64, fmt, iter};
 
-const LEVEL_NUM: usize = 3;
+/// Number of levels
+pub const LEVEL_NUM: usize = 3;
 
 /// The chance ratio of level 1 and level 2 tasks.
 const CHANCE_RATIO: u32 = 4;
@@ -33,7 +34,7 @@ const DEFAULT_CLEANUP_OLD_MAP_INTERVAL: Duration = Duration::from_secs(10);
 /// When local total elapsed time exceeds this value in microseconds, the local
 /// metrics is flushed to the global atomic metrics and try to trigger chance
 /// adjustment.
-const FLUSH_LOCAL_THRESHOLD_US: u64 = 100_000;
+pub(super) const FLUSH_LOCAL_THRESHOLD_US: u64 = 100_000;
 
 /// When the incremental total elapsed time exceeds this value, it will try to
 /// adjust level chances and reset the total elapsed time.
@@ -322,8 +323,7 @@ where
 struct LevelManager {
     level0_elapsed_us: IntCounter,
     total_elapsed_us: IntCounter,
-    task_elapsed_map: TaskElapsedMap,
-    level_time_threshold: [Duration; LEVEL_NUM - 1],
+    task_level_mgr: TaskLevelManager,
     level0_chance: Gauge,
     level0_proportion_target: f64,
     adjusting: AtomicBool,
@@ -347,25 +347,8 @@ impl LevelManager {
     where
         T: TaskCell,
     {
-        let extras = task_cell.mut_extras();
-        let task_id = extras.task_id;
-        let current_level = match extras.fixed_level {
-            Some(level) => level,
-            None => {
-                let running_time = extras
-                    .total_running_time
-                    .get_or_insert_with(|| self.task_elapsed_map.get_elapsed(task_id));
-                let running_time = running_time.as_duration();
-                self.level_time_threshold
-                    .iter()
-                    .enumerate()
-                    .find(|(_, &threshold)| running_time < threshold)
-                    .map(|(level, _)| level)
-                    .unwrap_or(LEVEL_NUM - 1) as u8
-            }
-        };
-        extras.current_level = current_level;
-        extras.schedule_time = Some(now());
+        self.task_level_mgr.adjust_task_level(task_cell);
+        task_cell.mut_extras().schedule_time = Some(now());
     }
 
     fn maybe_adjust_chance(&self) {
@@ -432,6 +415,44 @@ impl LevelManager {
     }
 }
 
+pub(super) struct TaskLevelManager {
+    task_elapsed_map: TaskElapsedMap,
+    level_time_threshold: [Duration; LEVEL_NUM - 1],
+}
+
+impl TaskLevelManager {
+    pub fn new(level_time_threshold: [Duration; LEVEL_NUM - 1]) -> Self {
+        Self {
+            task_elapsed_map: TaskElapsedMap::default(),
+            level_time_threshold,
+        }
+    }
+
+    pub fn adjust_task_level<T>(&self, task_cell: &mut T)
+    where
+        T: TaskCell,
+    {
+        let extras = task_cell.mut_extras();
+        let task_id = extras.task_id;
+        let current_level = match extras.fixed_level {
+            Some(level) => level,
+            None => {
+                let running_time = extras
+                    .total_running_time
+                    .get_or_insert_with(|| self.task_elapsed_map.get_elapsed(task_id));
+                let running_time = running_time.as_duration();
+                self.level_time_threshold
+                    .iter()
+                    .enumerate()
+                    .find(|(_, &threshold)| running_time < threshold)
+                    .map(|(level, _)| level)
+                    .unwrap_or(LEVEL_NUM - 1) as u8
+            }
+        };
+        extras.current_level = current_level;
+    }
+}
+
 pub(crate) struct ElapsedTime(AtomicU64);
 
 impl ElapsedTime {
@@ -439,7 +460,7 @@ impl ElapsedTime {
         Duration::from_micros(self.0.load(Relaxed) as u64)
     }
 
-    fn inc_by(&self, t: Duration) {
+    pub(super) fn inc_by(&self, t: Duration) {
         self.0.fetch_add(t.as_micros() as u64, Relaxed);
     }
 
@@ -650,8 +671,7 @@ impl Builder {
         let manager = Arc::new(LevelManager {
             level0_elapsed_us,
             total_elapsed_us,
-            task_elapsed_map: Default::default(),
-            level_time_threshold: config.level_time_threshold,
+            task_level_mgr: TaskLevelManager::new(config.level_time_threshold),
             level0_chance,
             level0_proportion_target: config.level0_proportion_target,
             adjusting: AtomicBool::new(false),
@@ -998,7 +1018,12 @@ mod tests {
             assert!(runner.handle(&mut locals[0], task_cell));
         }
         assert!(
-            manager.task_elapsed_map.get_elapsed(1).as_duration() >= Duration::from_millis(100)
+            manager
+                .task_level_mgr
+                .task_elapsed_map
+                .get_elapsed(1)
+                .as_duration()
+                >= Duration::from_millis(100)
         );
     }
 

--- a/src/queue/priority.rs
+++ b/src/queue/priority.rs
@@ -1,7 +1,7 @@
 // Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
 
 //! A priority task queue. Tasks are scheduled based on its priority, tasks with small priority
-//! value will be scheduler earlier than bigger onces.. User should implement The [`TaskPriorityProvider`]
+//! value will be scheduler earlier than bigger onces. User should implement The [`TaskPriorityProvider`]
 //! to provide the priority value for each task. The priority value is fetched from the
 //! [`TaskPriorityProvider`] at each time the task is scheduled.
 //!
@@ -86,11 +86,11 @@ where
 
 /// A trait used to generate priority value for each task.
 pub trait TaskPriorityProvider: Send + Sync + 'static {
-    /// Return a priority value of this task, all tasks in the priority queue is ordered by this value.
+    /// Return a priority value of this task, all tasks in the priority
+    /// queue is ordered by this value.
     fn get_priority(&self, extras: &Extras) -> u64;
 }
 
-///
 #[derive(Clone)]
 struct PriorityTaskManager {
     level_manager: Arc<TaskLevelManager>,
@@ -152,8 +152,8 @@ impl<T: TaskCell + Send + 'static> QueueCore<T> {
     }
 
     #[inline]
-    fn gen_key(&self, weight: u64) -> MapKey {
-        MapKey(weight, self.sequence.fetch_add(1, Ordering::Relaxed))
+    fn gen_key(&self, priority: u64) -> MapKey {
+        MapKey(priority, self.sequence.fetch_add(1, Ordering::Relaxed))
     }
 }
 
@@ -265,8 +265,7 @@ pub struct Config {
 }
 
 impl Config {
-    /// Sets the name of the multilevel task queue. Metrics of multilevel
-    /// task queues are available if name is provided.
+    /// Sets the name of the priority task queue. Metrics are available if name is provided.
     pub fn name(mut self, name: Option<impl Into<String>>) -> Self {
         self.name = name.map(Into::into);
         self
@@ -290,7 +289,7 @@ pub struct Builder {
 }
 
 impl Builder {
-    /// Creates a multilevel task queue builder with specified config and [`TaskPriorityProvider`].
+    /// Creates a priority task queue builder with specified config and [`TaskPriorityProvider`].
     pub fn new(config: Config, priority_manager: Arc<dyn TaskPriorityProvider>) -> Builder {
         let Config {
             name,

--- a/src/queue/priority.rs
+++ b/src/queue/priority.rs
@@ -156,7 +156,8 @@ impl<T: TaskCell + Send + 'static> QueueCore<T> {
     }
 }
 
-/// A holder to store task. The slot can be concurrently visit by multiple thread in the skip-list.
+/// A holder to store task. We wrap the value in an atomic ptr because the return value of pop()
+/// only provide readonly reference to this value, though in our can it's safe to just take it.
 struct Slot<T> {
     ptr: AtomicPtr<T>,
 }

--- a/src/queue/priority.rs
+++ b/src/queue/priority.rs
@@ -487,6 +487,8 @@ mod tests {
         }
         assert!(pq.is_empty());
 
+        // test dynamic level
+
         let mut run_task = |sleep_ms, level| {
             remote.spawn(MockTask::new(sleep_ms, 1));
             let mut task = pq.pop().unwrap().task_cell;
@@ -494,13 +496,9 @@ mod tests {
             runner.handle(&mut local, task);
         };
 
-        // test dynamic level
-        for _i in 0..2 {
-            run_task(3, 0);
-        }
+        run_task(5, 0);
         // after 5ms, the task should be put to level1
         run_task(95, 1);
-
         // after 100ms, the task should be put to level2
         run_task(1, 2);
     }

--- a/src/queue/priority.rs
+++ b/src/queue/priority.rs
@@ -1,0 +1,507 @@
+// Copyright 2022 TiKV Project Authors. Licensed under Apache-2.0.
+
+//! A priority task queue. Tasks are scheduled based on its priority, tasks with small priority
+//! value will be scheduler earlier than bigger onces.. User should implement The [`TaskPriorityProvider`]
+//! to provide the priority value for each task. The priority value is fetched from the
+//! [`TaskPriorityProvider`] at each time the task is scheduled.
+//!
+//! The task queue requires that the accompanying [`PriorityRunner`] must beused to collect necessary
+//! information.
+
+use std::{
+    sync::{
+        atomic::{AtomicBool, AtomicU64, Ordering},
+        Arc,
+    },
+    time::{Duration, Instant},
+};
+
+use crossbeam_skiplist::SkipMap;
+use prometheus::local::LocalIntCounter;
+use prometheus::IntCounter;
+
+use crate::metrics::*;
+use crate::pool::{Local, Runner, RunnerBuilder};
+use crate::queue::{
+    multilevel::{TaskLevelManager, FLUSH_LOCAL_THRESHOLD_US, LEVEL_NUM},
+    Extras, Pop, TaskCell,
+};
+
+// a wrapper of u64 with an extra sequence number to avoid duplicate value.
+#[derive(Eq, PartialEq, Ord, PartialOrd)]
+struct MapKey(u64, u64);
+
+/// The injector of a single level work stealing task queue.
+#[derive(Clone)]
+pub struct TaskInjector<T> {
+    queue: Arc<QueueCore<T>>,
+    task_manager: PriorityTaskManager,
+}
+
+fn set_schedule_time<T>(task_cell: &mut T)
+where
+    T: TaskCell,
+{
+    task_cell.mut_extras().schedule_time = Some(Instant::now());
+}
+
+impl<T> TaskInjector<T>
+where
+    T: TaskCell + Send,
+{
+    /// Pushes the task cell to the queue. The schedule time in the extras is
+    /// assigned to be now.
+    pub fn push(&self, mut task_cell: T) {
+        let priority = self.task_manager.prepare_before_push(&mut task_cell);
+        set_schedule_time(&mut task_cell);
+        self.queue.push(task_cell, priority);
+    }
+}
+
+/// The local queue is just a proxy of the global queue.
+pub(crate) struct LocalQueue<T> {
+    queue: Arc<QueueCore<T>>,
+    task_manager: PriorityTaskManager,
+}
+
+impl<T> LocalQueue<T>
+where
+    T: TaskCell + Send,
+{
+    pub(super) fn push(&mut self, mut task_cell: T) {
+        let priority = self.task_manager.prepare_before_push(&mut task_cell);
+        set_schedule_time(&mut task_cell);
+        self.queue.push(task_cell, priority);
+    }
+
+    pub(super) fn pop(&mut self) -> Option<Pop<T>> {
+        self.queue.pop()
+    }
+
+    pub(super) fn has_tasks_or_pull(&mut self) -> bool {
+        !self.queue.is_empty()
+    }
+}
+
+/// A trait used to generate priority value for each task.
+pub trait TaskPriorityProvider: Send + Sync + 'static {
+    /// Return a priority value of this task, all tasks in the priority queue is ordered by this value.
+    fn get_priority(&self, extras: &Extras) -> u64;
+}
+
+///
+#[derive(Clone)]
+struct PriorityTaskManager {
+    level_manager: Arc<TaskLevelManager>,
+    priority_manager: Arc<dyn TaskPriorityProvider>,
+}
+
+impl PriorityTaskManager {
+    fn prepare_before_push<T>(&self, task_cell: &mut T) -> u64
+    where
+        T: TaskCell,
+    {
+        self.level_manager.adjust_task_level(task_cell);
+        self.priority_manager.get_priority(task_cell.mut_extras())
+    }
+}
+
+/// The global priority queue. We use a `SkipMap` as a priority queue,
+/// The key is the priority and value is the task.
+struct QueueCore<T> {
+    pq: SkipMap<MapKey, Slot<T>>,
+    /// a global sequence generator to ensure all task keys are unique.
+    sequence: AtomicU64,
+}
+
+impl<T> QueueCore<T> {
+    fn new() -> Self {
+        Self {
+            pq: SkipMap::new(),
+            sequence: AtomicU64::new(0),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.pq.is_empty()
+    }
+}
+
+impl<T: TaskCell + Send + 'static> QueueCore<T> {
+    fn push(&self, msg: T, priority: u64) {
+        self.pq.insert(self.gen_key(priority), Slot::new(msg));
+    }
+
+    pub fn pop(&self) -> Option<Pop<T>> {
+        fn into_pop<T>(mut t: T) -> Pop<T>
+        where
+            T: TaskCell,
+        {
+            let schedule_time = t.mut_extras().schedule_time.unwrap();
+            Pop {
+                task_cell: t,
+                schedule_time,
+                from_local: false,
+            }
+        }
+
+        self.pq
+            .pop_front()
+            .map(|e| into_pop(e.value().take().unwrap()))
+    }
+
+    #[inline]
+    fn gen_key(&self, weight: u64) -> MapKey {
+        MapKey(weight, self.sequence.fetch_add(1, Ordering::Relaxed))
+    }
+}
+
+/// A holder to store task.
+struct Slot<T> {
+    ptr: *mut T,
+    consumed: AtomicBool,
+}
+
+unsafe impl<T: Send> Send for Slot<T> {}
+unsafe impl<T: Send> Sync for Slot<T> {}
+
+impl<T> Slot<T> {
+    fn new(value: T) -> Self {
+        Self {
+            ptr: Box::into_raw(Box::new(value)),
+            consumed: AtomicBool::new(false),
+        }
+    }
+
+    fn take(&self) -> Option<T> {
+        if !self.consumed.swap(true, Ordering::SeqCst) {
+            unsafe { Some(*Box::from_raw(self.ptr)) }
+        } else {
+            None
+        }
+    }
+}
+
+impl<T> Drop for Slot<T> {
+    fn drop(&mut self) {
+        self.take();
+    }
+}
+
+/// The runner for priority queues.
+///
+/// The runner helps collect additional information to support auto-adjust task level.
+/// [`PriorityRunnerBuiler`] is the [`RunnerBuilder`] for this runner.
+pub struct PriorityRunner<R> {
+    inner: R,
+    local_level0_elapsed_us: LocalIntCounter,
+    local_total_elapsed_us: LocalIntCounter,
+}
+
+impl<R, T> Runner for PriorityRunner<R>
+where
+    R: Runner<TaskCell = T>,
+    T: TaskCell,
+{
+    type TaskCell = T;
+
+    fn start(&mut self, local: &mut Local<T>) {
+        self.inner.start(local)
+    }
+
+    fn handle(&mut self, local: &mut Local<T>, mut task_cell: T) -> bool {
+        let extras = task_cell.mut_extras();
+        let level = extras.current_level();
+        let total_running_time = extras.total_running_time.clone();
+        let begin = Instant::now();
+        let res = self.inner.handle(local, task_cell);
+        let elapsed = begin.elapsed();
+        let elapsed_us = elapsed.as_micros() as u64;
+        if let Some(ref running_time) = total_running_time {
+            running_time.inc_by(elapsed);
+        }
+        if level == 0 {
+            self.local_level0_elapsed_us.inc_by(elapsed_us);
+        }
+        self.local_total_elapsed_us.inc_by(elapsed_us);
+        let local_total = self.local_total_elapsed_us.get();
+        if local_total > FLUSH_LOCAL_THRESHOLD_US {
+            self.local_level0_elapsed_us.flush();
+            self.local_total_elapsed_us.flush();
+        }
+        res
+    }
+
+    fn pause(&mut self, local: &mut Local<Self::TaskCell>) -> bool {
+        self.inner.pause(local)
+    }
+
+    fn resume(&mut self, local: &mut Local<Self::TaskCell>) {
+        self.inner.resume(local)
+    }
+
+    fn end(&mut self, local: &mut Local<Self::TaskCell>) {
+        self.inner.end(local)
+    }
+}
+
+/// The runner builder for priority task queues.
+///
+/// It can be created by [`Builder::runner_builder`].
+pub struct PriorityRunnerBuiler<B> {
+    inner: B,
+    level0_elapsed_us: IntCounter,
+    total_elapsed_us: IntCounter,
+}
+
+impl<B, R, T> RunnerBuilder for PriorityRunnerBuiler<B>
+where
+    B: RunnerBuilder<Runner = R>,
+    R: Runner<TaskCell = T>,
+    T: TaskCell,
+{
+    type Runner = PriorityRunner<R>;
+
+    fn build(&mut self) -> Self::Runner {
+        PriorityRunner {
+            inner: self.inner.build(),
+            local_level0_elapsed_us: self.level0_elapsed_us.local(),
+            local_total_elapsed_us: self.total_elapsed_us.local(),
+        }
+    }
+}
+
+/// The configurations of priority task queues.
+pub struct Config {
+    name: Option<String>,
+    level_time_threshold: [Duration; LEVEL_NUM - 1],
+}
+
+impl Config {
+    /// Sets the name of the multilevel task queue. Metrics of multilevel
+    /// task queues are available if name is provided.
+    pub fn name(mut self, name: Option<impl Into<String>>) -> Self {
+        self.name = name.map(Into::into);
+        self
+    }
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            name: None,
+            level_time_threshold: [Duration::from_millis(5), Duration::from_millis(100)],
+        }
+    }
+}
+
+/// The builder of a priority task queue.
+pub struct Builder {
+    manager: PriorityTaskManager,
+    level0_elapsed_us: IntCounter,
+    total_elapsed_us: IntCounter,
+}
+
+impl Builder {
+    /// Creates a multilevel task queue builder with specified config and [`TaskPriorityProvider`].
+    pub fn new(config: Config, priority_manager: Arc<dyn TaskPriorityProvider>) -> Builder {
+        let Config {
+            name,
+            level_time_threshold,
+        } = config;
+        let (level0_elapsed_us, total_elapsed_us) = if let Some(name) = name {
+            (
+                MULTILEVEL_LEVEL_ELAPSED
+                    .get_metric_with_label_values(&[&name, "0"])
+                    .unwrap(),
+                MULTILEVEL_LEVEL_ELAPSED
+                    .get_metric_with_label_values(&[&name, "total"])
+                    .unwrap(),
+            )
+        } else {
+            (
+                IntCounter::new("_", "_").unwrap(),
+                IntCounter::new("_", "_").unwrap(),
+            )
+        };
+        Self {
+            manager: PriorityTaskManager {
+                level_manager: Arc::new(TaskLevelManager::new(level_time_threshold)),
+                priority_manager,
+            },
+            level0_elapsed_us,
+            total_elapsed_us,
+        }
+    }
+
+    /// Creates a runner builder for the multilevel task queue with a normal runner builder.
+    pub fn runner_builder<B>(&self, inner_runner_builder: B) -> PriorityRunnerBuiler<B> {
+        PriorityRunnerBuiler {
+            inner: inner_runner_builder,
+            level0_elapsed_us: self.level0_elapsed_us.clone(),
+            total_elapsed_us: self.total_elapsed_us.clone(),
+        }
+    }
+
+    pub(crate) fn build_raw<T>(self, local_num: usize) -> (TaskInjector<T>, Vec<LocalQueue<T>>) {
+        let queue = Arc::new(QueueCore::new());
+        let local_queue = std::iter::repeat_with(|| LocalQueue {
+            queue: queue.clone(),
+            task_manager: self.manager.clone(),
+        })
+        .take(local_num)
+        .collect();
+
+        let injector = TaskInjector {
+            queue: queue,
+            task_manager: self.manager,
+        };
+
+        (injector, local_queue)
+    }
+
+    pub(crate) fn build<T>(
+        self,
+        local_num: usize,
+    ) -> (super::TaskInjector<T>, Vec<super::LocalQueue<T>>) {
+        let (injector, locals) = self.build_raw(local_num);
+        (
+            super::TaskInjector(super::InjectorInner::Priority(injector)),
+            locals
+                .into_iter()
+                .map(|i| super::LocalQueue(super::LocalQueueInner::Priority(i)))
+                .collect(),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread;
+
+    use super::*;
+    use crate::queue::{Extras, InjectorInner};
+    use rand::RngCore;
+    #[derive(Debug)]
+    struct MockTask {
+        sleep_ms: u64,
+        extras: Extras,
+    }
+
+    impl MockTask {
+        fn new(sleep_ms: u64, task_id: u64) -> Self {
+            MockTask {
+                sleep_ms,
+                extras: Extras::new_multilevel(task_id, None),
+            }
+        }
+    }
+
+    impl TaskCell for MockTask {
+        fn mut_extras(&mut self) -> &mut Extras {
+            &mut self.extras
+        }
+    }
+
+    struct MockRunner;
+
+    impl Runner for MockRunner {
+        type TaskCell = MockTask;
+
+        fn handle(&mut self, _local: &mut Local<MockTask>, task_cell: MockTask) -> bool {
+            thread::sleep(Duration::from_millis(task_cell.sleep_ms));
+            true
+        }
+    }
+
+    struct MockRunnerBuilder;
+
+    impl RunnerBuilder for MockRunnerBuilder {
+        type Runner = MockRunner;
+
+        fn build(&mut self) -> MockRunner {
+            MockRunner
+        }
+    }
+
+    #[test]
+    fn test_priority_queue() {
+        struct OrderByIdProvider;
+
+        impl TaskPriorityProvider for OrderByIdProvider {
+            fn get_priority(&self, extras: &Extras) -> u64 {
+                return extras.task_id();
+            }
+        }
+
+        let local_count = 5usize;
+        let builder = Builder::new(Config::default(), Arc::new(OrderByIdProvider));
+        let mut runner = builder.runner_builder(MockRunnerBuilder).build();
+        let (injecter, locals) = builder.build(local_count);
+        let pq = match &injecter.0 {
+            InjectorInner::Priority(p) => p.queue.clone(),
+            _ => unreachable!(),
+        };
+        let core = Arc::new(crate::pool::spawn::QueueCore::new(
+            injecter,
+            crate::pool::SchedConfig::default(),
+        ));
+        let mut locals: Vec<_> = locals
+            .into_iter()
+            .enumerate()
+            .map(|(i, l)| Local::new(i, l, core.clone()))
+            .collect();
+
+        let mut local = locals.pop().unwrap();
+        let remote = crate::Remote::new(core.clone());
+        for i in (0..5).rev() {
+            remote.spawn(MockTask::new(0, i));
+        }
+
+        for i in 0..5 {
+            let mut task = pq.pop().unwrap().task_cell;
+            assert_eq!(task.mut_extras().task_id(), i);
+        }
+
+        // test multiple threads
+        let task_per_thread = 10usize;
+        let mut handlers = Vec::with_capacity(local_count);
+        for mut local in locals {
+            let h = std::thread::spawn(move || {
+                let mut rng = rand::thread_rng();
+                for _i in 0..task_per_thread {
+                    let task = MockTask::new(0, rng.next_u64());
+                    local.spawn(task);
+                }
+            });
+            handlers.push(h);
+        }
+        for h in handlers {
+            h.join().unwrap();
+        }
+        let mut last_id = 0u64;
+        for _ in 0..task_per_thread * (local_count - 1) {
+            let mut task = pq.pop().unwrap().task_cell;
+            assert!(task.mut_extras().task_id() >= last_id);
+            last_id = task.mut_extras().task_id();
+        }
+        assert!(pq.is_empty());
+
+        let mut run_task = |sleep_ms, level| {
+            remote.spawn(MockTask::new(sleep_ms, 1));
+            let mut task = pq.pop().unwrap().task_cell;
+            assert_eq!(task.mut_extras().current_level(), level);
+            runner.handle(&mut local, task);
+        };
+
+        // test dynamic level
+        for _i in 0..2 {
+            run_task(3, 0);
+        }
+        // after 5ms, the task should be put to level1
+        run_task(95, 1);
+
+        // after 100ms, the task should be put to level2
+        run_task(1, 2);
+    }
+}


### PR DESCRIPTION
this PR introduces a new type of queue: priority queue. The priority queue sorts task by their priority value that can allow inserting tasks in the front or middle, so we can support a more flexible schedule policy.

### Why Priority

The default multi-level queue is suitable for most FIFO scenarios. But in cases that need more fine-grained control of the task schedule order, FIFO is not good enough. For example, in a shared environment for multiple users, the scheduler should schedule tasks from different users according to their share. In this case, a priority-based scheduler based on the total execution time by the user may be a workable solution.

### Drawbacks

The priority queue is not perfect for all cases. The scheduling overhead is a little bigger than the multi-level queue. And there is no default implementation that is suitable for common cases.  The schedule also doesn't implement the multi-level strategy that automatically degrades slow tasks. 

### Implement detail

The priority queue is backed by crossbeam-skiplist, the key is the priority value and the value is the task. The implementation attaches the key with an extra auto-incremented sequence number to ensure the key never duplicate with each other.

The user should provide an implementation of the trait `TaskPriorityPriovider` to generate the priority value of each task. 

### Benchmark Result

I test the priority queue performance by comparing the overall performance of tidb cluster with sysbench oltp_read_only and select_random_ranges workload.  
In this brief benchmark, the priority scheduler implements the mclock algorithm to support fair scheduling among multi resource groups. Becuase by default there is only one resource group, so it can be treat as a FIFO queue. The priority test code is: https://github.com/glorv/tikv/tree/qos-http and the nightly code is commit `2704588c6aaa1a269bb91499229e358d23cc636b`.

The benchmark is running on 3 * 8core tikv and 6 * 8 core tidb so tikv should be the performance bottleneck.
Result:

![图片](https://user-images.githubusercontent.com/5196885/205198939-24bff6de-27fe-412f-96fc-63a949405165.png)
(the first is priority queue and second is yatp multi-level queue)

The benchmark shows that the overhead of priority-queue is bigger than multi-level queue. The performance drops about 5% in oltp_read_only and 1% in select_random_ranges.



