### PR TITLE
queue: add try_evict_lowest API for priority-based queue eviction

### DIFF
--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -227,8 +227,10 @@ impl<T> Clone for Remote<T> {
 /// Note that implements of Runner assumes `Remote` is `Sync` and `Send`.
 /// So we need to use assert trait to ensure the constraint at compile time
 /// to avoid future breaks.
+#[allow(dead_code)]
 trait AssertSync: Sync {}
 impl<T: Send> AssertSync for Remote<T> {}
+#[allow(dead_code)]
 trait AssertSend: Send {}
 impl<T: Send> AssertSend for Remote<T> {}
 


### PR DESCRIPTION
issue # https://github.com/tikv/tikv/issues/19386
Add eviction support to the priority queue so that when a queue is full, a higher-priority incoming task can evict the lowest-priority queued task.

The API is exposed through QueueCore, TaskInjector (priority and outer), and Remote. Only priority queues support eviction; other queue types return None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Priority queues can now evict the lowest-priority task when a strictly higher-priority task arrives, improving scheduling under load.

* **Tests**
  * Added comprehensive eviction tests covering higher-priority eviction, equal/non-strict priority cases, empty-queue behavior, and concurrent stress scenarios to validate correctness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->