### PR TITLE
pool: fix scaled-down threads still processing tasks

### DIFF
--- a/src/pool/spawn.rs
+++ b/src/pool/spawn.rs
@@ -329,6 +329,11 @@ impl<T: TaskCell + Send> Local<T> {
                     if !self.core.mark_sleep() {
                         return false;
                     }
+                    // If this thread is above core_thread_count, go to sleep
+                    // without popping so scaled-down threads don't keep working.
+                    if id > self.core.config.core_thread_count.load(Ordering::SeqCst) {
+                        return true;
+                    }
                     task = self.local_queue.pop();
                     task.is_none()
                 },


### PR DESCRIPTION
Issue [#19498](https://github.com/tikv/tikv/issues/19498)
When threads are scaled down, threads with ID > core_thread_count should go to sleep immediately. Previously, the park validation callback would still pop tasks from the queue, causing scaled-down threads to keep working instead of sleeping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where worker threads continued processing work even after the thread pool was scaled down to a smaller number of active workers, ensuring they properly enter sleep mode when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->